### PR TITLE
Add web UI, park/onboard workflow, review-log table, and extended fixed schedule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+make build          # produces ./spd binary
+go build -o spd     # equivalent
+
+# Test
+go test ./...                    # run all tests
+go test ./database/...           # run only database tests
+go test ./database/ -run TestXxx # run a single test
+
+# Run CLI
+./spd --help
+
+# Run web UI (opens browser at http://localhost:7331)
+./spd serve
+make serve          # build + serve shorthand
+./spd serve --port 8080 --no-browser   # custom port, headless
+```
+
+No lint configuration is present; use `go vet ./...` for basic checks.
+
+## Architecture
+
+**Spaced** is a CLI spaced-repetition tool written in Go. The binary is `spd`.
+
+### Packages
+
+**`cmd/`** — Cobra command handlers, one file per subcommand (`add`, `pop`, `done`, `list`, `archive`, `delete`, `modify`, `snooze`, `stats`, `export`, `import`, `project`, `serve`). `root.go` initializes the DB and wires up the root command.
+
+**`web/`** — HTTP server and REST API handlers for the web UI. `server.go` sets up routing and embeds `web/static/` into the binary via `//go:embed`. `handlers.go` contains all REST endpoints (see REST API section). The SPA lives in `web/static/index.html` (vanilla HTML/CSS/JS, no build step).
+
+**`database/`** — All business logic and SQLite persistence. The DB lives at `~/.spaced/spaced.db`. Key files:
+- `database.go` — schema creation, session init, core topic CRUD
+- `projects.go` — project table and project/topic relationships
+- `sm2.go` — SM-2 spaced repetition algorithm (computes next interval and easiness factor from recall quality 0–5)
+- `filters.go` — unified filtered topic query (`TopicFilter` struct)
+- `snooze.go` — push `next_review_at` without advancing the review cycle
+- `stats.go`, `export.go`, `import.go`, `notes.go` — analytics, CSV/Markdown export/import, notes updates
+
+### Data model
+
+```go
+type Topic struct {
+    ID, ReviewCycle, IntervalDays int64
+    Topic, Notes                  string
+    CreatedAt, NextReviewAt       time.Time
+    Completed, Archived           bool
+    EasinessFactor                float64
+    ProjectID                     *int64
+    ProjectName                   string
+}
+```
+
+Topics belong to a Project (default project: `UNASSIGNED`). The schema uses a single SQLite file with a Topics ↔ Projects foreign key.
+
+### Review scheduling
+
+Two modes, selected per topic at `done` time:
+
+| Mode | Behaviour |
+|------|-----------|
+| Fixed | Deterministic cycle: day 1 → 3 → 8 → 15 → 30, then completed |
+| SM-2  | Adaptive: quality < 3 resets to 1-day interval; quality ≥ 3 grows interval by easiness factor |
+
+### Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `github.com/spf13/cobra` | CLI framework |
+| `github.com/mattn/go-sqlite3` | SQLite driver (CGO required) |
+| `github.com/olekukonko/tablewriter` | Formatted table output |
+| `github.com/fatih/color` | Coloured console output |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-.PHONY: build
+.PHONY: build serve
 build:
 	go build -o spd
+
+serve: build
+	./spd serve
 
 ${V}.SILENT:

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -13,6 +13,7 @@ var (
 	addProjectName string
 	addProjectID   int64
 	addNotes       string
+	addPark        bool
 )
 
 var addCmd = &cobra.Command{
@@ -70,15 +71,27 @@ Flags --project and --project-id are mutually exclusive.`,
 			resolvedProjectName = unassignedProject
 		}
 
-		var err error
+		var (
+			newID int64
+			err   error
+		)
 		if addNotes != "" {
-			err = database.AddTopicFull(topic, addNotes, projectID)
+			newID, err = database.AddTopicFull(topic, addNotes, projectID)
 		} else {
-			err = database.AddTopicWithProject(topic, projectID)
+			newID, err = database.AddTopicWithProject(topic, projectID)
 		}
 
 		if err != nil {
 			fmt.Println("Error adding topic:", err)
+			return
+		}
+
+		if addPark {
+			if err := database.ParkTopic(newID); err != nil {
+				fmt.Println("Error parking topic:", err)
+				return
+			}
+			fmt.Printf("Topic added to project %q (parked — not in revision cycle).\n", resolvedProjectName)
 			return
 		}
 		fmt.Printf("Topic added to project %q.\n", resolvedProjectName)
@@ -90,4 +103,5 @@ func init() {
 	addCmd.Flags().StringVar(&addProjectName, "project", "", "Assign to a project by name (created if needed)")
 	addCmd.Flags().Int64Var(&addProjectID, "project-id", 0, "Assign to a project by its numeric ID")
 	addCmd.Flags().StringVar(&addNotes, "notes", "", "Optional notes or context for the topic")
+	addCmd.Flags().BoolVar(&addPark, "park", false, "Park the topic without adding it to the revision cycle")
 }

--- a/cmd/done.go
+++ b/cmd/done.go
@@ -15,7 +15,7 @@ var doneCmd = &cobra.Command{
 	Short: "Mark a topic as reviewed and advance to the next cycle.",
 	Long: `Mark a topic as reviewed.
 
-Without --quality, uses the fixed schedule (Day 1 → 3 → 8 → 15 → 30).
+Without --quality, uses the fixed schedule (Day 1 → 4 → 11 → 25 → 55 → 115).
 With --quality (0–5), uses the SM-2 algorithm for adaptive intervals:
   0 = complete blackout
   1 = incorrect, remembered on seeing answer
@@ -48,6 +48,7 @@ With --quality (0–5), uses the SM-2 algorithm for adaptive intervals:
 				fmt.Println("Error marking topic as done:", err)
 				return
 			}
+			_ = database.LogReview(id)
 			topics, err := database.GetAllTopics()
 			if err != nil {
 				fmt.Printf("Done! Next review: %s\n", nextDate.Format("2006-01-02"))
@@ -73,6 +74,7 @@ With --quality (0–5), uses the SM-2 algorithm for adaptive intervals:
 			fmt.Println("Error marking topic as done:", err)
 			return
 		}
+		_ = database.LogReview(id)
 
 		topics, err := database.GetAllTopics()
 		if err != nil {

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -79,6 +79,6 @@ func init() {
 	rootCmd.AddCommand(modifyCmd)
 	modifyCmd.Flags().StringVar(&modifyTopic, "topic", "", "New topic text")
 	modifyCmd.Flags().StringVar(&modifyNotes, "notes", "", "New notes or context")
-	modifyCmd.Flags().Int64Var(&modifyReviewCycle, "review-cycle", 0, "New review cycle (0–4)")
+	modifyCmd.Flags().Int64Var(&modifyReviewCycle, "review-cycle", 0, "New review cycle (0–6)")
 	modifyCmd.Flags().StringVar(&modifyProject, "project", "", "Assign to a project (created if needed)")
 }

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"spaced/database"
+)
+
+var onboardCycle int64
+
+var onboardCmd = &cobra.Command{
+	Use:   "onboard <id>",
+	Short: "Onboard a parked topic back onto the revision cycle.",
+	Long: `Onboard a parked topic so it appears in review sessions again.
+By default the topic resumes from the cycle stage it was at when parked.
+Use --cycle to start from a specific stage (0–6).`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		id, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			fmt.Println("Error: invalid topic id")
+			return
+		}
+
+		var cycle *int64
+		if cmd.Flags().Changed("cycle") {
+			if onboardCycle < 0 || onboardCycle > 6 {
+				fmt.Println("Error: --cycle must be 0–6")
+				return
+			}
+			cycle = &onboardCycle
+		}
+
+		if err := database.OnboardTopic(id, cycle); err != nil {
+			fmt.Println("Error onboarding topic:", err)
+			return
+		}
+		fmt.Printf("Topic %d onboarded — it is now due for review.\n", id)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(onboardCmd)
+	onboardCmd.Flags().Int64Var(&onboardCycle, "cycle", 0, "Revision cycle stage to start from (0–6)")
+}

--- a/cmd/park.go
+++ b/cmd/park.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"spaced/database"
+)
+
+var parkCmd = &cobra.Command{
+	Use:   "park <id>",
+	Short: "Park a topic (suspend from revision cycle, preserving progress).",
+	Long: `Park a topic to remove it from the revision cycle without losing its progress.
+Parked topics remain visible in lists but are excluded from review sessions.
+Use 'onboard' to return a parked topic to the cycle.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		id, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			fmt.Println("Error: invalid topic id")
+			return
+		}
+		if err := database.ParkTopic(id); err != nil {
+			fmt.Println("Error parking topic:", err)
+			return
+		}
+		fmt.Printf("Topic %d parked. Use 'spd onboard %d' to resume it.\n", id, id)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(parkCmd)
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"spaced/web"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Launch the web UI in your browser",
+	Long:  "Start a local HTTP server and open the spaced web UI in your default browser.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		port, _ := cmd.Flags().GetInt("port")
+		noBrowser, _ := cmd.Flags().GetBool("no-browser")
+
+		srv, err := web.Start(port)
+		if err != nil {
+			return fmt.Errorf("failed to start server: %w", err)
+		}
+
+		url := fmt.Sprintf("http://localhost:%d", port)
+		fmt.Fprintf(os.Stdout, "Serving at %s — press Ctrl+C to stop\n", url)
+
+		if !noBrowser {
+			go func() {
+				time.Sleep(500 * time.Millisecond)
+				web.OpenBrowser(url)
+			}()
+		}
+
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+		<-quit
+
+		fmt.Fprintln(os.Stdout, "\nShutting down...")
+		web.Shutdown(srv)
+		return nil
+	},
+}
+
+func init() {
+	serveCmd.Flags().Int("port", 7331, "Port to listen on")
+	serveCmd.Flags().Bool("no-browser", false, "Do not open the browser automatically")
+	rootCmd.AddCommand(serveCmd)
+}

--- a/database/database.go
+++ b/database/database.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -21,6 +22,7 @@ type Topic struct {
 	ReviewCycle     int64
 	Completed       bool
 	Archived        bool
+	Parked          bool
 	EasinessFactor  float64
 	IntervalDays    int64
 	ProjectID       *int64
@@ -29,18 +31,17 @@ type Topic struct {
 
 var db *sql.DB
 
-// reviewSchedule maps review cycle → day number from creation shown to user.
-var reviewSchedule = []int{1, 3, 8, 15, 30}
+// cycleDays maps review cycle → absolute days from createdAt for next_review_at.
+// Cycle 0 = day 0 (immediate), then 1, 4, 11, 25, 55, 115.
+var cycleDays = []int{0, 1, 4, 11, 25, 55, 115}
 
-// cycleDays maps review cycle → days to add to createdAt to get next_review_at.
-var cycleDays = []int{0, 2, 7, 14, 29}
-
-// GetReviewDay returns the human-readable day number for a given review cycle.
+// GetReviewDay returns the day-from-creation label for a given review cycle.
+// Cycle 3 → "Day 11", cycle 4 → "Day 25", etc.
 func GetReviewDay(cycle int64) int {
-	if cycle < 0 || int(cycle) >= len(reviewSchedule) {
+	if cycle < 0 || int(cycle) >= len(cycleDays) {
 		return 0
 	}
-	return reviewSchedule[cycle]
+	return cycleDays[cycle]
 }
 
 func resolveDBPath() string {
@@ -87,6 +88,7 @@ func createTables() {
 		review_cycle     INT NOT NULL,
 		completed        BOOLEAN NOT NULL,
 		archived         BOOLEAN NOT NULL,
+		parked           BOOLEAN NOT NULL DEFAULT 0,
 		easiness_factor  REAL NOT NULL DEFAULT 2.5,
 		interval_days    INT NOT NULL DEFAULT 0,
 		project_id       INTEGER REFERENCES projects(id)
@@ -95,6 +97,15 @@ func createTables() {
 		log.Fatal(err)
 	}
 	createProjectsTable()
+	createReviewLogsTable()
+	migrateParkedColumn()
+}
+
+func migrateParkedColumn() {
+	_, err := db.Exec(`ALTER TABLE topics ADD COLUMN parked BOOLEAN NOT NULL DEFAULT 0`)
+	if err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		log.Fatal("migrate parked column:", err)
+	}
 }
 
 // nowFn can be swapped in tests for deterministic time.
@@ -102,7 +113,7 @@ var nowFn = func() time.Time { return time.Now() }
 
 // scanTopics reads a "topics LEFT JOIN projects" result set into []Topic.
 // Expected column order: id, topic, notes, created_at, next_review_at,
-// review_cycle, completed, archived, easiness_factor, interval_days,
+// review_cycle, completed, archived, parked, easiness_factor, interval_days,
 // project_id, project_name.
 func scanTopics(rows interface {
 	Next() bool
@@ -116,7 +127,7 @@ func scanTopics(rows interface {
 		var projectName sql.NullString
 		if err := rows.Scan(
 			&t.ID, &t.Topic, &t.Notes, &t.CreatedAt, &t.NextReviewAt,
-			&t.ReviewCycle, &t.Completed, &t.Archived,
+			&t.ReviewCycle, &t.Completed, &t.Archived, &t.Parked,
 			&t.EasinessFactor, &t.IntervalDays,
 			&projectID, &projectName,
 		); err != nil {
@@ -147,10 +158,10 @@ func AddTopic(topic string) error {
 func GetTopicsToReview() ([]Topic, error) {
 	rows, err := db.Query(`
 		SELECT t.id, t.topic, t.notes, t.created_at, t.next_review_at, t.review_cycle,
-		       t.completed, t.archived, t.easiness_factor, t.interval_days, t.project_id, p.name
+		       t.completed, t.archived, t.parked, t.easiness_factor, t.interval_days, t.project_id, p.name
 		FROM topics t
 		LEFT JOIN projects p ON t.project_id = p.id
-		WHERE t.next_review_at <= ? AND t.completed = false AND t.archived = false`,
+		WHERE t.next_review_at <= ? AND t.completed = false AND t.archived = false AND t.parked = false`,
 		nowFn(),
 	)
 	if err != nil {
@@ -169,17 +180,22 @@ func MarkTopicDone(id int64) (nextReviewAt time.Time, err error) {
 		return
 	}
 
-	if cycle == 4 {
+	if cycle == 6 {
 		_, err = db.Exec(`UPDATE topics SET completed = true WHERE id = ?`, id)
 		return
 	}
-	if cycle < 0 || cycle > 4 {
+	if cycle < 0 || cycle > 6 {
 		err = fmt.Errorf("invalid review cycle: %d", cycle)
 		return
 	}
 
+	// Schedule on the absolute day from creation. If that date is already past
+	// (overdue review), fall back to tomorrow so we never schedule into the past.
 	newCycle := cycle + 1
 	nextReviewAt = createdAt.AddDate(0, 0, cycleDays[newCycle])
+	if tomorrow := nowFn().AddDate(0, 0, 1); nextReviewAt.Before(tomorrow) {
+		nextReviewAt = tomorrow
+	}
 	_, err = db.Exec(
 		`UPDATE topics SET next_review_at = ?, review_cycle = ? WHERE id = ?`,
 		nextReviewAt, newCycle, id,
@@ -190,7 +206,7 @@ func MarkTopicDone(id int64) (nextReviewAt time.Time, err error) {
 func GetAllTopics() ([]Topic, error) {
 	rows, err := db.Query(`
 		SELECT t.id, t.topic, t.notes, t.created_at, t.next_review_at, t.review_cycle,
-		       t.completed, t.archived, t.easiness_factor, t.interval_days, t.project_id, p.name
+		       t.completed, t.archived, t.parked, t.easiness_factor, t.interval_days, t.project_id, p.name
 		FROM topics t
 		LEFT JOIN projects p ON t.project_id = p.id
 		WHERE t.archived = false
@@ -218,8 +234,8 @@ func ModifyTopic(id int64, newTopic string) error {
 }
 
 func UpdateTopicReviewCycle(id int64, newCycle int64) error {
-	if newCycle < 0 || newCycle > 4 {
-		return fmt.Errorf("invalid review cycle %d: must be 0–4", newCycle)
+	if newCycle < 0 || newCycle > 6 {
+		return fmt.Errorf("invalid review cycle %d: must be 0–6", newCycle)
 	}
 	var createdAt time.Time
 	if err := db.QueryRow(`SELECT created_at FROM topics WHERE id = ?`, id).

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -95,39 +95,33 @@ func TestMarkTopicDone_ProgressesThroughAllCycles(t *testing.T) {
 	id := topics[0].ID
 	createdAt := topics[0].CreatedAt
 
-	cases := []struct {
-		wantCycle       int64
-		wantDaysFromCreated int
-	}{
-		{1, 2},
-		{2, 7},
-		{3, 14},
-		{4, 29},
-	}
+	// next_review_at is always absolute from createdAt regardless of when the
+	// review actually happens (early, on-time, or late).
+	wantCycles := []int64{1, 2, 3, 4, 5, 6}
 
-	for _, c := range cases {
+	for _, wantCycle := range wantCycles {
 		if _, err := MarkTopicDone(id); err != nil {
-			t.Fatalf("MarkTopicDone → cycle %d: %v", c.wantCycle, err)
+			t.Fatalf("MarkTopicDone → cycle %d: %v", wantCycle, err)
 		}
 		topics, _ = GetAllTopics()
 		got := topics[0]
 
-		if got.ReviewCycle != c.wantCycle {
-			t.Errorf("review cycle: expected %d, got %d", c.wantCycle, got.ReviewCycle)
+		if got.ReviewCycle != wantCycle {
+			t.Errorf("review cycle: expected %d, got %d", wantCycle, got.ReviewCycle)
 		}
 
-		wantDate := createdAt.AddDate(0, 0, c.wantDaysFromCreated)
+		wantDate := createdAt.AddDate(0, 0, cycleDays[wantCycle])
 		diff := got.NextReviewAt.Sub(wantDate)
 		if diff < 0 {
 			diff = -diff
 		}
 		if diff > time.Second {
 			t.Errorf("next_review_at for cycle %d: expected %v, got %v (diff %v)",
-				c.wantCycle, wantDate, got.NextReviewAt, diff)
+				wantCycle, wantDate, got.NextReviewAt, diff)
 		}
 	}
 
-	// Fifth call marks as completed
+	// Seventh call marks as completed
 	if _, err := MarkTopicDone(id); err != nil {
 		t.Fatalf("final MarkTopicDone: %v", err)
 	}
@@ -240,11 +234,13 @@ func TestGetReviewDay(t *testing.T) {
 		cycle int64
 		want  int
 	}{
-		{0, 1},
-		{1, 3},
-		{2, 8},
-		{3, 15},
-		{4, 30},
+		{0, 0},
+		{1, 1},
+		{2, 4},
+		{3, 11},
+		{4, 25},
+		{5, 55},
+		{6, 115},
 	}
 	for _, c := range cases {
 		if got := GetReviewDay(c.cycle); got != c.want {

--- a/database/export.go
+++ b/database/export.go
@@ -26,7 +26,7 @@ func GetTopicsGroupedByProject() ([]TopicGroup, error) {
 
 	rows, err := db.Query(`
 		SELECT t.id, t.topic, t.notes, t.created_at, t.next_review_at, t.review_cycle,
-		       t.completed, t.archived, t.easiness_factor, t.interval_days, t.project_id, p.name
+		       t.completed, t.archived, t.parked, t.easiness_factor, t.interval_days, t.project_id, p.name
 		FROM topics t
 		LEFT JOIN projects p ON t.project_id = p.id
 		ORDER BY COALESCE(p.name, ''), t.created_at ASC`)

--- a/database/filters.go
+++ b/database/filters.go
@@ -10,7 +10,9 @@ type TopicFilter struct {
 	ProjectID       *int64 // if non-nil, restrict to this project
 	Overdue         bool   // only topics past their next_review_at
 	Completed       bool   // only completed topics
-	IncludeArchived bool   // include archived topics (default: exclude)
+	IncludeArchived bool   // also include archived topics (default: exclude)
+	ArchivedOnly    bool   // only archived topics
+	ParkedOnly      bool   // only parked topics
 }
 
 // GetTopicsFiltered returns topics matching the given filter.
@@ -30,8 +32,13 @@ func GetTopicsFiltered(f TopicFilter) ([]Topic, error) {
 	if f.Completed {
 		conds = append(conds, "t.completed = true")
 	}
-	if !f.IncludeArchived {
+	if f.ArchivedOnly {
+		conds = append(conds, "t.archived = true")
+	} else if !f.IncludeArchived {
 		conds = append(conds, "t.archived = false")
+	}
+	if f.ParkedOnly {
+		conds = append(conds, "t.parked = true")
 	}
 
 	where := ""
@@ -41,11 +48,11 @@ func GetTopicsFiltered(f TopicFilter) ([]Topic, error) {
 
 	query := fmt.Sprintf(`
 		SELECT t.id, t.topic, t.notes, t.created_at, t.next_review_at, t.review_cycle,
-		       t.completed, t.archived, t.easiness_factor, t.interval_days, t.project_id, p.name
+		       t.completed, t.archived, t.parked, t.easiness_factor, t.interval_days, t.project_id, p.name
 		FROM topics t
 		LEFT JOIN projects p ON t.project_id = p.id
 		%s
-		ORDER BY t.completed ASC, t.created_at DESC`, where)
+		ORDER BY t.completed ASC, t.next_review_at DESC`, where)
 
 	rows, err := db.Query(query, args...)
 	if err != nil {

--- a/database/filters_test.go
+++ b/database/filters_test.go
@@ -52,7 +52,7 @@ func TestGetTopicsFiltered_Completed(t *testing.T) {
 	topics, _ := GetAllTopics()
 	for _, tp := range topics {
 		if tp.Topic == "Done Topic" {
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 7; i++ {
 				MarkTopicDone(tp.ID)
 			}
 		}

--- a/database/import.go
+++ b/database/import.go
@@ -233,9 +233,9 @@ func ImportGroups(groups []ImportGroup) (int, error) {
 			}
 			var err error
 			if projectID != 0 {
-				err = AddTopicFull(t.Topic, t.Notes, projectID)
+				_, err = AddTopicFull(t.Topic, t.Notes, projectID)
 			} else {
-				err = AddTopicWithNotes(t.Topic, t.Notes)
+				_, err = AddTopicWithNotes(t.Topic, t.Notes)
 			}
 			if err != nil {
 				return count, fmt.Errorf("topic %q: %w", t.Topic, err)

--- a/database/notes.go
+++ b/database/notes.go
@@ -1,25 +1,43 @@
 package database
 
+import "time"
+
 // AddTopicWithNotes inserts a topic with an initial notes string.
-func AddTopicWithNotes(topic, notes string) error {
+func AddTopicWithNotes(topic, notes string) (int64, error) {
 	now := nowFn()
-	_, err := db.Exec(
+	res, err := db.Exec(
 		`INSERT INTO topics (topic, notes, created_at, next_review_at, review_cycle, completed, archived)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		topic, notes, now, now, 0, false, false,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
 }
 
 // AddTopicFull inserts a topic with notes and a project association.
-func AddTopicFull(topic, notes string, projectID int64) error {
+func AddTopicFull(topic, notes string, projectID int64) (int64, error) {
 	now := nowFn()
-	_, err := db.Exec(
+	return addTopicFullWithDate(topic, notes, projectID, now)
+}
+
+// AddTopicFullWithDate inserts a topic with an explicit initial review date.
+func AddTopicFullWithDate(topic, notes string, projectID int64, reviewAt time.Time) (int64, error) {
+	return addTopicFullWithDate(topic, notes, projectID, reviewAt)
+}
+
+func addTopicFullWithDate(topic, notes string, projectID int64, reviewAt time.Time) (int64, error) {
+	now := nowFn()
+	res, err := db.Exec(
 		`INSERT INTO topics (topic, notes, created_at, next_review_at, review_cycle, completed, archived, project_id)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		topic, notes, now, now, 0, false, false, projectID,
+		topic, notes, now, reviewAt, 0, false, false, projectID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
 }
 
 // UpdateNotes replaces the notes field for a topic.

--- a/database/notes_test.go
+++ b/database/notes_test.go
@@ -7,7 +7,7 @@ import (
 func TestAddTopicWithNotes(t *testing.T) {
 	setupTestDB(t)
 
-	if err := AddTopicWithNotes("Merge Sort", "Divide and conquer, O(n log n)"); err != nil {
+	if _, err := AddTopicWithNotes("Merge Sort", "Divide and conquer, O(n log n)"); err != nil {
 		t.Fatalf("AddTopicWithNotes: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestAddTopicFullOptions(t *testing.T) {
 	setupTestDB(t)
 
 	pID, _ := GetOrCreateProject("Go")
-	err := AddTopicFull("Goroutines", "Lightweight threads managed by the Go runtime", pID)
+	_, err := AddTopicFull("Goroutines", "Lightweight threads managed by the Go runtime", pID)
 	if err != nil {
 		t.Fatalf("AddTopicFull: %v", err)
 	}

--- a/database/park.go
+++ b/database/park.go
@@ -1,0 +1,26 @@
+package database
+
+// ParkTopic removes a topic from the revision cycle without losing its cycle progress.
+func ParkTopic(id int64) error {
+	_, err := db.Exec(`UPDATE topics SET parked = true WHERE id = ?`, id)
+	return err
+}
+
+// OnboardTopic returns a parked topic to the revision cycle, scheduling it as immediately due.
+// If cycle is non-nil the topic's review_cycle is set to that value first; otherwise the
+// existing review_cycle is preserved. completed is always reset to false.
+func OnboardTopic(id int64, cycle *int64) error {
+	now := nowFn()
+	if cycle != nil {
+		_, err := db.Exec(
+			`UPDATE topics SET parked = false, completed = false, review_cycle = ?, next_review_at = ? WHERE id = ?`,
+			*cycle, now, id,
+		)
+		return err
+	}
+	_, err := db.Exec(
+		`UPDATE topics SET parked = false, completed = false, next_review_at = ? WHERE id = ?`,
+		now, id,
+	)
+	return err
+}

--- a/database/projects.go
+++ b/database/projects.go
@@ -114,14 +114,17 @@ func DeleteProject(id int64) error {
 // ── Topic ↔ Project ───────────────────────────────────────────────────────────
 
 // AddTopicWithProject inserts a topic and associates it with a project.
-func AddTopicWithProject(topic string, projectID int64) error {
+func AddTopicWithProject(topic string, projectID int64) (int64, error) {
 	now := nowFn()
-	_, err := db.Exec(
+	res, err := db.Exec(
 		`INSERT INTO topics (topic, created_at, next_review_at, review_cycle, completed, archived, project_id)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		topic, now, now, 0, false, false, projectID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
 }
 
 // AssignTopicToProject updates a topic's project association.
@@ -134,7 +137,7 @@ func AssignTopicToProject(topicID, projectID int64) error {
 func GetTopicsByProject(projectID int64) ([]Topic, error) {
 	rows, err := db.Query(`
 		SELECT t.id, t.topic, t.notes, t.created_at, t.next_review_at, t.review_cycle,
-		       t.completed, t.archived, t.easiness_factor, t.interval_days, t.project_id, p.name
+		       t.completed, t.archived, t.parked, t.easiness_factor, t.interval_days, t.project_id, p.name
 		FROM topics t
 		LEFT JOIN projects p ON t.project_id = p.id
 		WHERE t.project_id = ?

--- a/database/projects_test.go
+++ b/database/projects_test.go
@@ -101,7 +101,7 @@ func TestAddTopicWithProject(t *testing.T) {
 	setupTestDB(t)
 
 	pID, _ := GetOrCreateProject("Algorithms")
-	if err := AddTopicWithProject("Binary Search", pID); err != nil {
+	if _, err := AddTopicWithProject("Binary Search", pID); err != nil {
 		t.Fatalf("AddTopicWithProject: %v", err)
 	}
 

--- a/database/review_logs.go
+++ b/database/review_logs.go
@@ -1,0 +1,94 @@
+package database
+
+import "fmt"
+
+// ActivityDay holds per-day counts for the progress chart.
+type ActivityDay struct {
+	Date     string `json:"date"`
+	Added    int    `json:"added"`
+	Reviewed int    `json:"reviewed"`
+}
+
+func createReviewLogsTable() {
+	_, err := db.Exec(`
+	CREATE TABLE IF NOT EXISTS review_logs (
+		id         INTEGER PRIMARY KEY AUTOINCREMENT,
+		topic_id   INTEGER NOT NULL,
+		reviewed_at TIMESTAMP NOT NULL
+	);`)
+	if err != nil {
+		panic(fmt.Sprintf("create review_logs table: %v", err))
+	}
+}
+
+// LogReview records a review event for the given topic at the current time.
+func LogReview(topicID int64) error {
+	_, err := db.Exec(
+		`INSERT INTO review_logs (topic_id, reviewed_at) VALUES (?, ?)`,
+		topicID, nowFn(),
+	)
+	return err
+}
+
+// GetTopicActivity returns per-day added and reviewed counts for the last N days
+// (including today), always returning a contiguous date series with no gaps.
+func GetTopicActivity(days int) ([]ActivityDay, error) {
+	now := nowFn()
+
+	// Build a complete date range so the chart has no gaps.
+	result := make([]ActivityDay, days)
+	dateIdx := make(map[string]int, days)
+	for i := 0; i < days; i++ {
+		d := now.AddDate(0, 0, -(days - 1 - i)).Format("2006-01-02")
+		result[i] = ActivityDay{Date: d}
+		dateIdx[d] = i
+	}
+
+	startDay := now.AddDate(0, 0, -(days - 1)).Format("2006-01-02")
+
+	// Topics added per day.
+	rows, err := db.Query(`
+		SELECT date(created_at) AS d, COUNT(*)
+		FROM topics
+		WHERE date(created_at) >= ?
+		GROUP BY date(created_at)`, startDay)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d string
+		var cnt int
+		if err := rows.Scan(&d, &cnt); err != nil {
+			return nil, err
+		}
+		if idx, ok := dateIdx[d]; ok {
+			result[idx].Added = cnt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Reviews completed per day.
+	rows2, err := db.Query(`
+		SELECT date(reviewed_at) AS d, COUNT(*)
+		FROM review_logs
+		WHERE date(reviewed_at) >= ?
+		GROUP BY date(reviewed_at)`, startDay)
+	if err != nil {
+		return nil, err
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var d string
+		var cnt int
+		if err := rows2.Scan(&d, &cnt); err != nil {
+			return nil, err
+		}
+		if idx, ok := dateIdx[d]; ok {
+			result[idx].Reviewed = cnt
+		}
+	}
+	return result, rows2.Err()
+}

--- a/database/stats.go
+++ b/database/stats.go
@@ -1,10 +1,13 @@
 package database
 
+import "time"
+
 // Stats holds aggregate counts for the dashboard.
 type Stats struct {
 	Total      int
 	Completed  int
 	InProgress int
+	Parked     int
 	Overdue    int
 	DueToday   int
 	Archived   int
@@ -33,21 +36,35 @@ func GetStats() (Stats, error) {
 		return s, err
 	}
 
-	s.InProgress = s.Total - s.Completed
+	// Parked (non-archived)
+	err = db.QueryRow(`SELECT COUNT(*) FROM topics WHERE parked = true AND archived = false`).Scan(&s.Parked)
+	if err != nil {
+		return s, err
+	}
 
-	// Due today (next_review_at <= now, not completed, not archived)
+	s.InProgress = s.Total - s.Completed - s.Parked
+
 	now := nowFn()
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	endOfDay := startOfDay.Add(24 * time.Hour)
+
+	// DueToday: all items needing review today or earlier (includes overdue)
 	err = db.QueryRow(
-		`SELECT COUNT(*) FROM topics WHERE next_review_at <= ? AND completed = false AND archived = false`,
-		now,
+		`SELECT COUNT(*) FROM topics WHERE next_review_at <= ? AND completed = false AND archived = false AND parked = false`,
+		endOfDay,
 	).Scan(&s.DueToday)
 	if err != nil {
 		return s, err
 	}
 
-	// Overdue means past next_review_at and not completed (same as due today in practice,
-	// but we surface it as a distinct label so callers can decide how to present it).
-	s.Overdue = s.DueToday
+	// Overdue: strictly past due (before start of today)
+	err = db.QueryRow(
+		`SELECT COUNT(*) FROM topics WHERE next_review_at < ? AND completed = false AND archived = false AND parked = false`,
+		startOfDay,
+	).Scan(&s.Overdue)
+	if err != nil {
+		return s, err
+	}
 
 	// Project count
 	err = db.QueryRow(`SELECT COUNT(*) FROM projects`).Scan(&s.Projects)

--- a/database/stats_test.go
+++ b/database/stats_test.go
@@ -48,7 +48,7 @@ func TestGetStats_CountsCompleted(t *testing.T) {
 	topics, _ := GetAllTopics()
 	for _, tp := range topics {
 		if tp.Topic == "A" {
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 7; i++ {
 				MarkTopicDone(tp.ID)
 			}
 		}
@@ -83,7 +83,32 @@ func TestGetStats_Overdue(t *testing.T) {
 		t.Errorf("expected 1 overdue, got %d", stats.Overdue)
 	}
 	if stats.DueToday != 1 {
-		t.Errorf("expected 1 due today (also overdue counts as due), got %d", stats.DueToday)
+		t.Errorf("expected 1 due today (overdue topics count as due), got %d", stats.DueToday)
+	}
+}
+
+func TestGetStats_ParkedExcludedFromInProgress(t *testing.T) {
+	setupTestDB(t)
+
+	AddTopic("Active")
+	AddTopic("ToBeParked")
+
+	topics, _ := GetAllTopics()
+	for _, tp := range topics {
+		if tp.Topic == "ToBeParked" {
+			ParkTopic(tp.ID)
+		}
+	}
+
+	stats, _ := GetStats()
+	if stats.Parked != 1 {
+		t.Errorf("expected 1 parked, got %d", stats.Parked)
+	}
+	if stats.InProgress != 1 {
+		t.Errorf("expected InProgress=1 (parked excluded), got %d", stats.InProgress)
+	}
+	if stats.Total != 2 {
+		t.Errorf("expected Total=2, got %d", stats.Total)
 	}
 }
 

--- a/tasks/T-001-bulk-operations.md
+++ b/tasks/T-001-bulk-operations.md
@@ -1,0 +1,32 @@
+# T-001: Bulk Operations in Web UI
+
+## Status
+**TODO**
+
+## Summary
+Allow users to select multiple topics and apply a single action (snooze, archive, assign to project) to all of them at once.
+
+## Context
+Every action in the Topics tab is per-topic: snooze, archive, and project-assign all require individual clicks. When doing housekeeping on a large topic set — e.g. archiving everything in a completed project or snoozing a batch of low-priority topics — this becomes tedious. Bulk operations would reduce this to a two-click workflow.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `web/static/index.html` | Add row checkboxes, bulk action toolbar, JS handlers |
+| `web/handlers.go` | Add bulk endpoints (or reuse existing per-topic endpoints in a loop) |
+
+### Key decisions
+- TBD: server-side bulk endpoint vs. client-side sequential API calls (simpler, acceptable for <100 items)
+- TBD: scope — which actions to support (snooze N days, archive, project-assign)
+
+### Technical details
+TBD
+
+## Validation
+- Select N topics → bulk action → verify all N affected
+- Verify partial failure (one topic already archived) doesn't block others
+
+## Dependencies
+None

--- a/tasks/T-002-web-import.md
+++ b/tasks/T-002-web-import.md
@@ -1,0 +1,35 @@
+# T-002: Import via Web UI
+
+## Status
+**TODO**
+
+## Summary
+Add a file-upload import flow to the web UI so users can migrate or onboard topics without dropping to the terminal.
+
+## Context
+Export works in the browser (Markdown and CSV download), but import is CLI-only (`spd import <file>`). Users who manage their data entirely in the web UI are blocked when they want to restore from an export or migrate from another tool. A file-upload widget on an Import tab (or alongside the Export section) would make the tool self-contained.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `web/static/index.html` | Add Import tab or section; file input; JS upload handler |
+| `web/handlers.go` | Add `POST /api/import` endpoint accepting multipart form-data |
+| `web/server.go` | Register the new route |
+| `database/import.go` | No change expected (existing import logic is reusable) |
+
+### Key decisions
+- TBD: new "Import" tab vs. combined "Export / Import" tab
+- TBD: whether to show a dry-run preview before committing
+
+### Technical details
+TBD — existing `database.ImportFromCSV` / `database.ImportFromMarkdown` functions handle the parsing; the web layer just needs to accept the upload and route to the right importer.
+
+## Validation
+- Upload a previously exported `.csv` → verify topics appear
+- Upload a `.md` export → verify topics appear
+- Upload an invalid file → verify user-friendly error message
+
+## Dependencies
+None

--- a/tasks/T-003-topic-tagging.md
+++ b/tasks/T-003-topic-tagging.md
@@ -1,0 +1,37 @@
+# T-003: Topic Tagging
+
+## Status
+**TODO**
+
+## Summary
+Add cross-cutting tags to topics, orthogonal to the existing project grouping, so users can filter across projects by subject or theme.
+
+## Context
+Projects are containers: a topic belongs to exactly one project. There is no way to express cross-cutting concerns (e.g. `#math`, `#interview-prep`, `#work`) that span multiple projects. Tags would allow filtering like "show all interview-prep topics regardless of project," which is not possible today.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `database/database.go` | Add `tags` column to topics table (comma-separated string or junction table) |
+| `database/filters.go` | Add `Tags []string` to `TopicFilter`; extend query to filter by tag |
+| `database/*.go` | Update CRUD functions to read/write tags |
+| `web/handlers.go` | Expose tags in topic JSON; add tag filter query param |
+| `web/static/index.html` | Tag chips on topic cards/rows; tag input in Add/Edit modal; tag filter in Topics tab |
+| `cmd/add.go`, `cmd/modify.go` | Add `--tags` flag |
+
+### Key decisions
+- TBD: comma-separated column (simpler, harder to query) vs. junction table (cleaner, more migration work)
+- TBD: whether tags appear in the Review Queue cards
+
+### Technical details
+TBD
+
+## Validation
+- Add topic with tags → verify tags persist and display
+- Filter by tag → verify only tagged topics shown
+- CLI `--tags` flag → verify tags stored
+
+## Dependencies
+None

--- a/tasks/T-004-review-session-cli.md
+++ b/tasks/T-004-review-session-cli.md
@@ -1,0 +1,34 @@
+# T-004: Interactive Review Session (CLI)
+
+## Status
+**TODO**
+
+## Summary
+Add a `spd session` command that walks through all due topics interactively — display topic, wait for recall rating, advance to the next — without requiring manual ID lookup and copy-paste.
+
+## Context
+The current CLI review flow is: `spd pop` (see due topics) → copy ID → `spd done <id>` → repeat. This is friction-heavy. The web UI's Review Queue eliminates this by showing cards one at a time, but a terminal-native version would let keyboard-focused users study without opening a browser. The flow mirrors Anki's "study now" mode.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `cmd/session.go` | New file: `session` Cobra command with interactive loop |
+| `cmd/root.go` | Register `sessionCmd` |
+
+### Key decisions
+- TBD: ordering (overdue-first vs. original pop ordering)
+- TBD: whether to support `--quality` inline (SM-2 mode) or fixed-only
+- TBD: exit behaviour on Ctrl-C (save progress up to interruption)
+
+### Technical details
+TBD — reuse `database.GetTopicsForReview()` for the topic list, `database.MarkTopicDone()` / `database.MarkTopicDoneWithQuality()` for advancement, and `database.LogReview()` for the activity log.
+
+## Validation
+- `spd session` with 3 due topics → walk through all 3 → verify next_review_at updated for each
+- Ctrl-C mid-session → verify already-reviewed topics are saved
+- `spd session` with no due topics → verify graceful empty message
+
+## Dependencies
+None

--- a/tasks/T-005-review-history-panel.md
+++ b/tasks/T-005-review-history-panel.md
@@ -1,0 +1,33 @@
+# T-005: Per-Topic Review History Panel
+
+## Status
+**TODO**
+
+## Summary
+Add a history drawer in the web UI showing when a topic was reviewed and how its interval evolved, so users can see the SM-2 progression and build trust in the algorithm.
+
+## Context
+There is no way to see a topic's review history. The `review_logs` table records every review timestamp, but it is only used for the aggregate activity chart. Users who want to know "when did I last review this?" or "is the interval actually growing?" have no way to find out. A history panel (slide-in drawer or expandable row) would surface this data per topic.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `web/handlers.go` | Add `GET /api/topics/{id}/history` returning review_logs rows for the topic |
+| `web/server.go` | Register the new route |
+| `web/static/index.html` | "History" button on topic rows; drawer/modal rendering the timeline |
+
+### Key decisions
+- TBD: drawer vs. modal vs. expandable table row
+- TBD: whether to show interval_days snapshots (requires storing them per review) or just timestamps
+
+### Technical details
+TBD — `review_logs` currently stores only `(topic_id, reviewed_at)`; interval snapshots would require a schema change to add `interval_days` to that table.
+
+## Validation
+- Review a topic 3 times via CLI and web → open history → verify 3 entries with correct timestamps
+- Topic with no reviews → history shows empty state
+
+## Dependencies
+None (read-only; does not require T-004)

--- a/tasks/T-006-notifications.md
+++ b/tasks/T-006-notifications.md
@@ -1,0 +1,33 @@
+# T-006: Notifications / Daily Reminders
+
+## Status
+**TODO**
+
+## Summary
+Add a mechanism to notify the user when topics are due, so reviews happen without needing to remember to open the tool.
+
+## Context
+The tool currently has no push mechanism. Reviews only happen when the user actively opens the CLI or web UI. A daily reminder (desktop notification, OS notification, or a `spd notify` command suitable for cron) would close the loop and make the tool behave more like a habit rather than a task.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `cmd/notify.go` | New file: `spd notify` command — prints due count or sends OS notification |
+
+### Key decisions
+- TBD: delivery mechanism — stdout summary (cron-friendly), macOS `osascript` notification, cross-platform approach
+- TBD: whether to embed this in `serve` as a scheduled background job vs. a standalone command
+- TBD: configurable notification time (morning digest vs. real-time)
+
+### Technical details
+TBD — `database.GetStats().DueToday` gives the count; `database.GetTopicsForReview()` gives the list for a richer message.
+
+## Validation
+- `spd notify` with 0 due → exits cleanly with no-op or "nothing due" message
+- `spd notify` with N due → emits correct count
+- Cron entry `0 9 * * * spd notify` works without interactive shell
+
+## Dependencies
+None

--- a/tasks/T-007-difficulty-heatmap.md
+++ b/tasks/T-007-difficulty-heatmap.md
@@ -1,0 +1,34 @@
+# T-007: Calendar Difficulty Heatmap
+
+## Status
+**TODO**
+
+## Summary
+Colour-code calendar days by average SM-2 quality score rather than just pending/completed dots, giving a visual sense of which periods were hard and whether retention is improving over time.
+
+## Context
+The calendar currently shows red (pending) and green (completed) dots per day. This tells you *whether* you reviewed but nothing about *how well*. Users on SM-2 scheduling could benefit from seeing effort over time — consistently low quality scores signal a topic needs more attention or should be restructured. A heatmap layer on the calendar would make this visible at a glance.
+
+## Implementation
+
+### Files changed
+| File | Change |
+|------|--------|
+| `database/review_logs.go` | Add `quality` column to `review_logs` (schema migration); update `LogReview` to accept quality |
+| `web/handlers.go` | Update calendar data endpoint to include avg quality per day |
+| `web/static/index.html` | Render day cells with a colour gradient based on avg quality (green=easy, red=hard) |
+
+### Key decisions
+- TBD: whether to store quality in `review_logs` now (schema migration) or derive it from a separate table
+- TBD: colour scale — continuous gradient vs. 3 buckets (easy/medium/hard)
+- TBD: whether to show the heatmap alongside existing dots or replace them
+
+### Technical details
+TBD — requires `review_logs` schema change to add `quality INT` (nullable for fixed-schedule reviews). The `LogReview` signature would expand to `LogReview(topicID int64, quality *int) error`, propagating through the CLI `done` and web `markDone` callers.
+
+## Validation
+- Review 5 topics with varying qualities → calendar shows colour gradient reflecting avg quality
+- Fixed-schedule reviews (no quality) → day renders neutral colour, not skewed
+
+## Dependencies
+Depends on existing `review_logs` table. Quality storage would be a prerequisite for accurate heatmap data.

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -1,0 +1,635 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"spaced/database"
+)
+
+// ── DTOs ─────────────────────────────────────────────────────────────────────
+
+type topicDTO struct {
+	ID             int64     `json:"id"`
+	Topic          string    `json:"topic"`
+	Notes          string    `json:"notes"`
+	CreatedAt      time.Time `json:"created_at"`
+	NextReviewAt   time.Time `json:"next_review_at"`
+	ReviewCycle    int64     `json:"review_cycle"`
+	ReviewDay      int       `json:"review_day"`
+	Completed      bool      `json:"completed"`
+	Archived       bool      `json:"archived"`
+	Parked         bool      `json:"parked"`
+	EasinessFactor float64   `json:"easiness_factor"`
+	IntervalDays   int64     `json:"interval_days"`
+	ProjectID      *int64    `json:"project_id"`
+	ProjectName    string    `json:"project_name"`
+}
+
+type projectDTO struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type calendarDay struct {
+	Date      string     `json:"date"`
+	Pending   int        `json:"pending"`
+	Completed int        `json:"completed"`
+	Topics    []topicDTO `json:"topics,omitempty"`
+}
+
+func toDTO(t database.Topic) topicDTO {
+	return topicDTO{
+		ID:             t.ID,
+		Topic:          t.Topic,
+		Notes:          t.Notes,
+		CreatedAt:      t.CreatedAt,
+		NextReviewAt:   t.NextReviewAt,
+		ReviewCycle:    t.ReviewCycle,
+		ReviewDay:      database.GetReviewDay(t.ReviewCycle),
+		Completed:      t.Completed,
+		Archived:       t.Archived,
+		Parked:         t.Parked,
+		EasinessFactor: t.EasinessFactor,
+		IntervalDays:   t.IntervalDays,
+		ProjectID:      t.ProjectID,
+		ProjectName:    t.ProjectName,
+	}
+}
+
+func toDTOs(topics []database.Topic) []topicDTO {
+	out := make([]topicDTO, 0, len(topics))
+	for _, t := range topics {
+		out = append(out, toDTO(t))
+	}
+	return out
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	writeJSON(w, code, map[string]string{"error": msg})
+}
+
+func parseID(segment string) (int64, bool) {
+	id, err := strconv.ParseInt(segment, 10, 64)
+	return id, err == nil
+}
+
+// splitPath splits the URL path after a prefix and returns the remaining segments.
+// e.g. "/api/topics/42/done" with prefix "/api/topics/" → ["42","done"]
+func splitPath(path, prefix string) []string {
+	trimmed := strings.TrimPrefix(path, prefix)
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+// ── Stats ─────────────────────────────────────────────────────────────────────
+
+func handleStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	stats, err := database.GetStats()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, stats)
+}
+
+// ── Topics collection: GET /api/topics, POST /api/topics ─────────────────────
+
+func handleTopics(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		listTopics(w, r)
+	case http.MethodPost:
+		createTopic(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func listTopics(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	f := database.TopicFilter{}
+
+	if pid := q.Get("project_id"); pid != "" {
+		id, ok := parseID(pid)
+		if !ok {
+			writeError(w, http.StatusBadRequest, "invalid project_id")
+			return
+		}
+		f.ProjectID = &id
+	}
+	f.Overdue = q.Get("overdue") == "true"
+	f.Completed = q.Get("completed") == "true"
+	if q.Get("archived") == "true" {
+		f.ArchivedOnly = true
+	} else {
+		f.IncludeArchived = q.Get("include_archived") == "true"
+	}
+
+	topics, err := database.GetTopicsFiltered(f)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toDTOs(topics))
+}
+
+func createTopic(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Topic       string `json:"topic"`
+		Notes       string `json:"notes"`
+		ProjectName string `json:"project_name"`
+		Parked      *bool  `json:"parked"`
+		ReviewDate  string `json:"review_date"` // optional, YYYY-MM-DD
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if strings.TrimSpace(body.Topic) == "" {
+		writeError(w, http.StatusBadRequest, "topic is required")
+		return
+	}
+
+	projectName := body.ProjectName
+	if projectName == "" {
+		projectName = "UNASSIGNED"
+	}
+	pid, err := database.GetOrCreateProject(projectName)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var newID int64
+	if body.ReviewDate != "" {
+		reviewAt, err := time.Parse("2006-01-02", body.ReviewDate)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "review_date must be YYYY-MM-DD")
+			return
+		}
+		newID, err = database.AddTopicFullWithDate(body.Topic, body.Notes, pid, reviewAt)
+	} else {
+		newID, err = database.AddTopicFull(body.Topic, body.Notes, pid)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// parked defaults to true (UI default); caller must explicitly send false to onboard.
+	shouldPark := body.Parked == nil || *body.Parked
+	if shouldPark {
+		if err := database.ParkTopic(newID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"ok": "true"})
+}
+
+// ── Topics/review: GET /api/topics/review ────────────────────────────────────
+
+func handleTopicsReview(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	topics, err := database.GetTopicsToReview()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toDTOs(topics))
+}
+
+// ── Individual topic: /api/topics/:id/* ──────────────────────────────────────
+
+func handleTopic(w http.ResponseWriter, r *http.Request) {
+	segs := splitPath(r.URL.Path, "/api/topics/")
+	if len(segs) < 1 {
+		writeError(w, http.StatusBadRequest, "missing topic id")
+		return
+	}
+	id, ok := parseID(segs[0])
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid topic id")
+		return
+	}
+
+	action := ""
+	if len(segs) > 1 {
+		action = segs[1]
+	}
+
+	switch {
+	case r.Method == http.MethodDelete && action == "":
+		deleteTopic(w, r, id)
+	case r.Method == http.MethodPut && action == "done":
+		markDone(w, r, id)
+	case r.Method == http.MethodPut && action == "modify":
+		modifyTopic(w, r, id)
+	case r.Method == http.MethodPut && action == "snooze":
+		snoozeTopic(w, r, id)
+	case r.Method == http.MethodPut && action == "archive":
+		archiveTopic(w, r, id)
+	case r.Method == http.MethodPut && action == "unarchive":
+		unarchiveTopic(w, r, id)
+	case r.Method == http.MethodPut && action == "park":
+		parkTopicHandler(w, id)
+	case r.Method == http.MethodPut && action == "onboard":
+		onboardTopicHandler(w, r, id)
+	default:
+		writeError(w, http.StatusNotFound, fmt.Sprintf("unknown action: %s %s", r.Method, action))
+	}
+}
+
+func deleteTopic(w http.ResponseWriter, _ *http.Request, id int64) {
+	if err := database.DeleteTopic(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func markDone(w http.ResponseWriter, r *http.Request, id int64) {
+	var body struct {
+		Quality *int `json:"quality"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	var (
+		next      time.Time
+		completed bool
+		err       error
+	)
+	if body.Quality != nil {
+		next, err = database.MarkTopicDoneWithQuality(id, *body.Quality)
+	} else {
+		next, err = database.MarkTopicDone(id)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = database.LogReview(id)
+
+	completed, _, err = database.GetTopicStatus(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"next_review_at": next,
+		"completed":      completed,
+	})
+}
+
+func modifyTopic(w http.ResponseWriter, r *http.Request, id int64) {
+	var body struct {
+		Topic       *string `json:"topic"`
+		Notes       *string `json:"notes"`
+		ReviewCycle *int64  `json:"review_cycle"`
+		ProjectID   *int64  `json:"project_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	if body.Topic != nil {
+		if err := database.ModifyTopic(id, *body.Topic); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	if body.Notes != nil {
+		if err := database.UpdateNotes(id, *body.Notes); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	if body.ReviewCycle != nil {
+		if err := database.UpdateTopicReviewCycle(id, *body.ReviewCycle); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	if body.ProjectID != nil {
+		if err := database.AssignTopicToProject(id, *body.ProjectID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func snoozeTopic(w http.ResponseWriter, r *http.Request, id int64) {
+	var body struct {
+		Days int `json:"days"`
+	}
+	body.Days = 1
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	if body.Days < 1 {
+		body.Days = 1
+	}
+	if err := database.SnoozeTopic(id, body.Days); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func archiveTopic(w http.ResponseWriter, _ *http.Request, id int64) {
+	if err := database.ArchiveTopic(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func unarchiveTopic(w http.ResponseWriter, _ *http.Request, id int64) {
+	if err := database.UnarchiveTopic(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func parkTopicHandler(w http.ResponseWriter, id int64) {
+	if err := database.ParkTopic(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func onboardTopicHandler(w http.ResponseWriter, r *http.Request, id int64) {
+	var body struct {
+		Cycle *int64 `json:"cycle"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	if err := database.OnboardTopic(id, body.Cycle); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+// ── Calendar: GET /api/calendar?year=&month= ─────────────────────────────────
+
+func handleCalendar(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	q := r.URL.Query()
+	yearStr := q.Get("year")
+	monthStr := q.Get("month")
+
+	now := time.Now()
+	year := now.Year()
+	month := int(now.Month())
+
+	if yearStr != "" {
+		if v, err := strconv.Atoi(yearStr); err == nil {
+			year = v
+		}
+	}
+	if monthStr != "" {
+		if v, err := strconv.Atoi(monthStr); err == nil && v >= 1 && v <= 12 {
+			month = v
+		}
+	}
+
+	// Fetch all non-archived topics; group by next_review_at date within the month.
+	topics, err := database.GetTopicsFiltered(database.TopicFilter{IncludeArchived: false})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	days := map[string]*calendarDay{}
+	for _, t := range topics {
+		if t.NextReviewAt.Year() != year || int(t.NextReviewAt.Month()) != month {
+			continue
+		}
+		dateKey := t.NextReviewAt.Format("2006-01-02")
+		day, ok := days[dateKey]
+		if !ok {
+			day = &calendarDay{Date: dateKey}
+			days[dateKey] = day
+		}
+		dto := toDTO(t)
+		if t.Completed {
+			day.Completed++
+		} else {
+			day.Pending++
+		}
+		day.Topics = append(day.Topics, dto)
+	}
+
+	result := make([]calendarDay, 0, len(days))
+	for _, d := range days {
+		result = append(result, *d)
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// ── Projects collection: GET /api/projects, POST /api/projects ───────────────
+
+func handleProjects(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		listProjects(w, r)
+	case http.MethodPost:
+		createProject(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func listProjects(w http.ResponseWriter, _ *http.Request) {
+	projects, err := database.GetAllProjects()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	out := make([]projectDTO, 0, len(projects))
+	for _, p := range projects {
+		out = append(out, projectDTO{ID: p.ID, Name: p.Name, Description: p.Description})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func createProject(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if strings.TrimSpace(body.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if err := database.AddProjectWithDescription(body.Name, body.Description); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"ok": "true"})
+}
+
+// ── Individual project: /api/projects/:id/* ───────────────────────────────────
+
+func handleProject(w http.ResponseWriter, r *http.Request) {
+	segs := splitPath(r.URL.Path, "/api/projects/")
+	if len(segs) < 1 {
+		writeError(w, http.StatusBadRequest, "missing project id")
+		return
+	}
+	id, ok := parseID(segs[0])
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid project id")
+		return
+	}
+
+	action := ""
+	if len(segs) > 1 {
+		action = segs[1]
+	}
+
+	switch {
+	case r.Method == http.MethodDelete && action == "":
+		deleteProject(w, id)
+	case r.Method == http.MethodPut && action == "rename":
+		renameProject(w, r, id)
+	case r.Method == http.MethodPut && action == "describe":
+		describeProject(w, r, id)
+	default:
+		writeError(w, http.StatusNotFound, fmt.Sprintf("unknown action: %s %s", r.Method, action))
+	}
+}
+
+func deleteProject(w http.ResponseWriter, id int64) {
+	if err := database.DeleteProject(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func renameProject(w http.ResponseWriter, r *http.Request, id int64) {
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if strings.TrimSpace(body.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if err := database.RenameProject(id, body.Name); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+func describeProject(w http.ResponseWriter, r *http.Request, id int64) {
+	var body struct {
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if err := database.UpdateProjectDescription(id, body.Description); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+}
+
+// ── Stats history: GET /api/stats/history?days=30 ────────────────────────────
+
+func handleStatsHistory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	days := 30
+	if d := r.URL.Query().Get("days"); d != "" {
+		if v, err := strconv.Atoi(d); err == nil && v > 0 && v <= 365 {
+			days = v
+		}
+	}
+	activity, err := database.GetTopicActivity(days)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, activity)
+}
+
+// ── Export: GET /api/export?format=markdown|csv ───────────────────────────────
+
+func handleExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "markdown"
+	}
+
+	groups, err := database.GetTopicsGroupedByProject()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var content, mime, filename string
+	switch format {
+	case "csv":
+		content = database.RenderCSV(groups)
+		mime = "text/csv"
+		filename = "spaced-export.csv"
+	default:
+		content = database.RenderMarkdown(groups)
+		mime = "text/plain; charset=utf-8"
+		filename = "spaced-export.md"
+	}
+
+	w.Header().Set("Content-Type", mime)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(content))
+}

--- a/web/server.go
+++ b/web/server.go
@@ -1,0 +1,86 @@
+package web
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+//go:embed static
+var staticFiles embed.FS
+
+// Start registers all routes and starts listening on the given port.
+// It returns the *http.Server so the caller can shut it down gracefully.
+func Start(port int) (*http.Server, error) {
+	mux := http.NewServeMux()
+
+	// Static SPA — strip the "static/" prefix from the embedded FS.
+	subFS, err := fs.Sub(staticFiles, "static")
+	if err != nil {
+		return nil, fmt.Errorf("embed sub: %w", err)
+	}
+	// Wrap with no-cache middleware so browsers always fetch the latest binary build.
+	mux.Handle("/", noCacheMiddleware(http.FileServer(http.FS(subFS))))
+
+	// API — order matters: exact paths must be registered before prefix paths.
+	mux.HandleFunc("/api/stats/history", handleStatsHistory)
+	mux.HandleFunc("/api/stats", handleStats)
+	mux.HandleFunc("/api/calendar", handleCalendar)
+	mux.HandleFunc("/api/export", handleExport)
+	mux.HandleFunc("/api/topics/review", handleTopicsReview)
+	mux.HandleFunc("/api/topics", handleTopics)
+	mux.HandleFunc("/api/topics/", handleTopic)
+	mux.HandleFunc("/api/projects", handleProjects)
+	mux.HandleFunc("/api/projects/", handleProject)
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", port),
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("server error: %v\n", err)
+		}
+	}()
+
+	return srv, nil
+}
+
+// OpenBrowser opens the given URL in the system default browser.
+func OpenBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}
+
+// noCacheMiddleware sets headers that prevent browsers from serving stale cached pages.
+func noCacheMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Shutdown gracefully stops the server with a 5-second timeout.
+func Shutdown(srv *http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx)
+}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,0 +1,1385 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>spaced</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #f8fafc;
+    --surface: #ffffff;
+    --border: #e2e8f0;
+    --text: #1e293b;
+    --muted: #64748b;
+    --primary: #6366f1;
+    --primary-hover: #4f46e5;
+    --red: #ef4444;
+    --red-bg: #fef2f2;
+    --green: #22c55e;
+    --green-bg: #f0fdf4;
+    --amber: #f59e0b;
+    --amber-bg: #fffbeb;
+    --radius: 8px;
+    --shadow: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.06);
+  }
+
+  body.dark {
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --border: #334155;
+    --text: #f1f5f9;
+    --muted: #94a3b8;
+    --red-bg: #2d1515;
+    --green-bg: #0f2318;
+    --amber-bg: #1f1a0a;
+    --shadow: 0 1px 3px rgba(0,0,0,.4), 0 1px 2px rgba(0,0,0,.3);
+  }
+
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+         background: var(--bg); color: var(--text); font-size: 14px; line-height: 1.5;
+         transition: background .2s, color .2s; }
+
+  /* ── Nav ─────────────────────────────────────────────────────────── */
+  nav { background: var(--surface); border-bottom: 1px solid var(--border);
+        display: flex; align-items: center; gap: 4px; padding: 0 20px; height: 52px;
+        position: sticky; top: 0; z-index: 100; box-shadow: var(--shadow); }
+  .nav-brand { font-weight: 700; font-size: 16px; color: var(--primary);
+               letter-spacing: -0.5px; margin-right: 16px; }
+  .nav-tab { padding: 6px 14px; border-radius: var(--radius); border: none;
+             background: none; cursor: pointer; font-size: 13px; font-weight: 500;
+             color: var(--muted); transition: all .15s; }
+  .nav-tab:hover { background: var(--bg); color: var(--text); }
+  .nav-tab.active { background: var(--primary); color: #fff; }
+  .badge { display: inline-flex; align-items: center; justify-content: center;
+           background: var(--red); color: #fff; border-radius: 99px;
+           font-size: 10px; font-weight: 700; min-width: 18px; height: 18px;
+           padding: 0 5px; margin-left: 5px; vertical-align: middle; }
+  .nav-spacer { flex: 1; }
+  .dark-toggle { padding: 6px 10px; border-radius: var(--radius); border: 1px solid var(--border);
+                 background: var(--bg); cursor: pointer; font-size: 15px; transition: all .15s; }
+  .dark-toggle:hover { background: var(--border); }
+
+  /* ── Layout ──────────────────────────────────────────────────────── */
+  main { max-width: 1100px; margin: 0 auto; padding: 24px 20px; }
+  .tab-panel { display: none; }
+  .tab-panel.active { display: block; }
+
+  /* ── Headings & toolbars ─────────────────────────────────────────── */
+  .page-header { display: flex; align-items: center; justify-content: space-between;
+                 margin-bottom: 20px; flex-wrap: wrap; gap: 10px; }
+  .page-title { font-size: 20px; font-weight: 700; }
+  .toolbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+  /* ── Buttons ─────────────────────────────────────────────────────── */
+  .btn { display: inline-flex; align-items: center; gap: 5px; padding: 6px 14px;
+         border-radius: var(--radius); border: 1px solid var(--border);
+         font-size: 13px; font-weight: 500; cursor: pointer; transition: all .15s;
+         background: var(--surface); color: var(--text); }
+  .btn:hover { background: var(--bg); }
+  .btn-primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+  .btn-primary:hover { background: var(--primary-hover); border-color: var(--primary-hover); }
+  .btn-danger { background: var(--red); color: #fff; border-color: var(--red); }
+  .btn-danger:hover { opacity: .85; }
+  .btn-sm { padding: 3px 9px; font-size: 12px; }
+  .btn-ghost { border-color: transparent; background: transparent; }
+  .btn-ghost:hover { background: var(--bg); border-color: var(--border); }
+  .btn-active { background: var(--primary); color: #fff; border-color: var(--primary); }
+
+  /* ── Group header (Review Queue) ─────────────────────────────────── */
+  .group-header { display: flex; align-items: center; gap: 10px; margin: 20px 0 10px;
+                  font-size: 12px; font-weight: 700; text-transform: uppercase;
+                  letter-spacing: .06em; color: var(--muted); }
+  .group-header:first-child { margin-top: 0; }
+  .group-header::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+  .group-date-label { white-space: nowrap; }
+  .group-count { background: var(--border); color: var(--text); border-radius: 99px;
+                 font-size: 10px; font-weight: 700; padding: 1px 7px; }
+
+  /* ── Cards (Review Queue) ────────────────────────────────────────── */
+  .card-list { display: flex; flex-direction: column; gap: 10px; }
+  .card { background: var(--surface); border: 1px solid var(--border);
+          border-radius: var(--radius); padding: 16px; box-shadow: var(--shadow); }
+  .card-body { font-size: 15px; font-weight: 500; margin-bottom: 8px; }
+  .card-meta { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+  .chip { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 99px;
+          background: var(--bg); border: 1px solid var(--border); color: var(--muted); }
+  .chip-primary { background: #ede9fe; color: var(--primary); border-color: #c4b5fd; }
+  .chip-green { background: var(--green-bg); color: #15803d; border-color: #86efac; }
+  body.dark .chip-primary { background: #2e2860; color: #a5b4fc; border-color: #4f46e5; }
+  body.dark .chip-green { background: #0f2318; color: #4ade80; border-color: #166534; }
+  .card-actions { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+  .quality-picker { display: none; gap: 4px; align-items: center; flex-wrap: wrap; margin-top: 8px; }
+  .quality-picker.open { display: flex; }
+  .quality-picker span { font-size: 11px; color: var(--muted); }
+  .q-btn { width: 30px; height: 28px; padding: 0; font-size: 12px; font-weight: 700;
+           border-radius: 6px; }
+
+  /* ── Empty state ─────────────────────────────────────────────────── */
+  .empty { text-align: center; padding: 48px 20px; color: var(--muted); }
+  .empty-icon { font-size: 36px; margin-bottom: 8px; }
+  .empty-text { font-size: 15px; }
+
+  /* ── Table ───────────────────────────────────────────────────────── */
+  .table-wrap { background: var(--surface); border: 1px solid var(--border);
+                border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); }
+  table { width: 100%; border-collapse: collapse; }
+  th { background: var(--bg); text-align: left; padding: 10px 14px;
+       font-size: 11px; font-weight: 700; text-transform: uppercase;
+       letter-spacing: .06em; color: var(--muted); border-bottom: 1px solid var(--border); }
+  td { padding: 10px 14px; border-bottom: 1px solid var(--border); vertical-align: middle; }
+  tr:last-child td { border-bottom: none; }
+  tr.overdue td { background: var(--red-bg); }
+  tr.completed td { background: var(--green-bg); color: var(--muted); }
+  .topic-text { font-weight: 500; }
+  .notes-text { font-size: 12px; color: var(--muted); margin-top: 2px;
+                max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* ── Topics filter ───────────────────────────────────────────────── */
+  .topics-filter { margin-bottom: 12px; }
+  .topics-filter input { width: 100%; max-width: 360px; padding: 7px 11px;
+    border: 1px solid var(--border); border-radius: var(--radius); font-size: 13px;
+    background: var(--bg); color: var(--text); }
+  .topics-filter input:focus { outline: none; border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(99,102,241,.15); }
+
+  /* ── Topics sub-tabs ─────────────────────────────────────────────── */
+  .topics-subtabs { display: flex; gap: 2px; border-bottom: 2px solid var(--border);
+                    margin-bottom: 16px; }
+  .subtab { padding: 8px 18px; border: none; background: none; cursor: pointer;
+            font-size: 13px; font-weight: 600; color: var(--muted);
+            border-bottom: 2px solid transparent; margin-bottom: -2px;
+            transition: color .15s, border-color .15s; }
+  .subtab:hover { color: var(--text); }
+  .subtab.active { color: var(--primary); border-bottom-color: var(--primary); }
+
+  /* ── Project link ─────────────────────────────────────────────────── */
+  .project-link { cursor: pointer; }
+  .project-link:hover .chip { opacity: .8; text-decoration: underline; }
+
+  /* ── Project view panel ───────────────────────────────────────────── */
+  #project-view { display: none; background: var(--surface); border: 1px solid var(--border);
+                  border-radius: var(--radius); padding: 20px; margin-bottom: 16px;
+                  box-shadow: var(--shadow); }
+  #project-view.open { display: block; }
+  .project-view-header { display: flex; align-items: center;
+                         justify-content: space-between; margin-bottom: 14px; }
+  .project-view-title { font-size: 16px; font-weight: 700; }
+
+  /* ── Calendar ────────────────────────────────────────────────────── */
+  .cal-header { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+  .cal-month-label { font-size: 18px; font-weight: 700; min-width: 160px; }
+  .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr);
+              background: var(--surface); border: 1px solid var(--border);
+              border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); }
+  .cal-dow { background: var(--bg); text-align: center; padding: 8px 0;
+             font-size: 11px; font-weight: 700; text-transform: uppercase;
+             letter-spacing: .06em; color: var(--muted);
+             border-bottom: 1px solid var(--border); }
+  .cal-cell { min-height: 72px; padding: 8px; border-right: 1px solid var(--border);
+              border-bottom: 1px solid var(--border); cursor: default; position: relative; }
+  .cal-cell:nth-child(7n) { border-right: none; }
+  .cal-cell.other-month { background: var(--bg); opacity: .5; }
+  .cal-cell.today { background: #ede9fe; }
+  body.dark .cal-cell.today { background: #2e2860; }
+  .cal-cell.has-tasks { cursor: pointer; }
+  .cal-cell.has-tasks:hover { background: #f5f3ff; }
+  body.dark .cal-cell.has-tasks:hover { background: #2a275a; }
+  .cal-cell.selected { outline: 2px solid var(--primary); outline-offset: -2px; }
+  .cal-day-num { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+  .cal-dots { display: flex; gap: 4px; flex-wrap: wrap; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .dot-red { background: var(--red); }
+  .dot-green { background: var(--green); }
+
+  /* ── Calendar day detail (below grid) ───────────────────────────── */
+  .cal-detail { display: none; margin-top: 16px; background: var(--surface);
+                border: 1px solid var(--border); border-radius: var(--radius);
+                box-shadow: var(--shadow); overflow: hidden; }
+  .cal-detail.open { display: block; }
+  .cal-detail-header { display: flex; align-items: center; justify-content: space-between;
+                       padding: 12px 16px; border-bottom: 1px solid var(--border);
+                       background: var(--bg); }
+  .cal-detail-title { font-size: 14px; font-weight: 700; }
+  .cal-detail-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 8px;
+                     max-height: 360px; overflow-y: auto; }
+
+  /* ── Stats ───────────────────────────────────────────────────────── */
+  .stats-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+                gap: 14px; margin-bottom: 24px; }
+  .stat-card { background: var(--surface); border: 1px solid var(--border);
+               border-radius: var(--radius); padding: 20px 16px; box-shadow: var(--shadow);
+               text-align: center; }
+  .stat-value { font-size: 32px; font-weight: 800; line-height: 1; margin-bottom: 6px; }
+  .stat-label { font-size: 12px; font-weight: 600; text-transform: uppercase;
+                letter-spacing: .06em; color: var(--muted); }
+  .stat-card.danger .stat-value { color: var(--red); }
+  .stat-card.warn .stat-value { color: var(--amber); }
+  .stat-card.good .stat-value { color: var(--green); }
+  .stat-card.primary .stat-value { color: var(--primary); }
+
+  /* ── Chart ───────────────────────────────────────────────────────── */
+  .chart-card { background: var(--surface); border: 1px solid var(--border);
+                border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+  .chart-header { display: flex; align-items: center; justify-content: space-between;
+                  margin-bottom: 14px; flex-wrap: wrap; gap: 8px; }
+  .chart-title { font-size: 15px; font-weight: 700; }
+  .chart-legend { display: flex; gap: 14px; }
+  .legend-item { display: flex; align-items: center; gap: 5px; font-size: 12px; color: var(--muted); }
+  .legend-dot { width: 10px; height: 10px; border-radius: 50%; }
+
+  /* ── Modal ───────────────────────────────────────────────────────── */
+  .modal-backdrop { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.4);
+                    z-index: 300; align-items: center; justify-content: center; }
+  .modal-backdrop.open { display: flex; }
+  .modal { background: var(--surface); border-radius: 12px; padding: 24px;
+           width: 480px; max-width: 95vw; max-height: 85vh; overflow-y: auto;
+           box-shadow: 0 20px 60px rgba(0,0,0,.3); border: 1px solid var(--border); }
+  .modal-title { font-size: 17px; font-weight: 700; margin-bottom: 18px; }
+  .field { margin-bottom: 14px; }
+  .field label { display: block; font-size: 12px; font-weight: 600;
+                 text-transform: uppercase; letter-spacing: .06em;
+                 color: var(--muted); margin-bottom: 5px; }
+  .field input, .field textarea, .field select {
+    width: 100%; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px;
+    font-size: 14px; font-family: inherit; background: var(--bg); color: var(--text); }
+  .field textarea { min-height: 80px; resize: vertical; }
+  .field input:focus, .field textarea:focus, .field select:focus {
+    outline: none; border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(99,102,241,.15); }
+  .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 18px; }
+
+  /* ── Export ──────────────────────────────────────────────────────── */
+  .export-section { background: var(--surface); border: 1px solid var(--border);
+                    border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow);
+                    margin-bottom: 16px; }
+  .export-section h3 { font-size: 14px; font-weight: 700; margin-bottom: 10px; }
+  .export-preview { margin-top: 14px; }
+  .export-preview pre { background: var(--bg); border: 1px solid var(--border);
+                         border-radius: 6px; padding: 12px; font-size: 12px;
+                         overflow-x: auto; max-height: 300px; overflow-y: auto;
+                         color: var(--text); }
+
+  /* ── Projects table ──────────────────────────────────────────────── */
+  .new-project-form { background: var(--surface); border: 1px solid var(--border);
+                      border-radius: var(--radius); padding: 16px; margin-bottom: 16px;
+                      box-shadow: var(--shadow); display: none; }
+  .new-project-form.open { display: block; }
+  .inline-form { display: flex; gap: 8px; align-items: flex-end; flex-wrap: wrap; }
+  .inline-field { flex: 1; min-width: 140px; }
+  .inline-field label { display: block; font-size: 11px; font-weight: 600;
+                         text-transform: uppercase; letter-spacing: .06em;
+                         color: var(--muted); margin-bottom: 4px; }
+  .inline-field input { width: 100%; padding: 6px 10px; border: 1px solid var(--border);
+                         border-radius: 6px; font-size: 13px; background: var(--bg); color: var(--text); }
+
+  /* ── Spinner ─────────────────────────────────────────────────────── */
+  .spinner { display: inline-block; width: 16px; height: 16px;
+             border: 2px solid var(--border); border-top-color: var(--primary);
+             border-radius: 50%; animation: spin .6s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* ── Toast ───────────────────────────────────────────────────────── */
+  #toast { position: fixed; bottom: 24px; right: 24px; background: #1e293b; color: #fff;
+           padding: 10px 18px; border-radius: var(--radius); font-size: 13px;
+           box-shadow: 0 4px 20px rgba(0,0,0,.3); opacity: 0; transform: translateY(10px);
+           transition: all .25s; pointer-events: none; z-index: 999; max-width: 320px; }
+  #toast.show { opacity: 1; transform: translateY(0); }
+  #toast.error { background: var(--red); }
+</style>
+</head>
+<body>
+
+<nav>
+  <span class="nav-brand">spaced</span>
+  <button class="nav-tab active" data-tab="review">Review <span id="review-count" class="badge" style="display:none">0</span></button>
+  <button class="nav-tab" data-tab="topics">Topics</button>
+  <button class="nav-tab" data-tab="calendar">Calendar</button>
+  <button class="nav-tab" data-tab="projects">Projects</button>
+  <button class="nav-tab" data-tab="stats">Stats</button>
+  <button class="nav-tab" data-tab="export">Export</button>
+  <div class="nav-spacer"></div>
+  <button class="dark-toggle" id="dark-toggle" onclick="toggleDark()" title="Toggle dark mode">🌙</button>
+</nav>
+
+<main>
+
+  <!-- ── Review Queue ─────────────────────────────────────────────── -->
+  <div id="tab-review" class="tab-panel active">
+    <div class="page-header">
+      <h1 class="page-title">Review Queue</h1>
+    </div>
+    <div id="review-list" class="card-list">
+      <div class="empty"><div class="spinner"></div></div>
+    </div>
+  </div>
+
+  <!-- ── All Topics ───────────────────────────────────────────────── -->
+  <div id="tab-topics" class="tab-panel">
+    <div class="page-header">
+      <h1 class="page-title">Topics</h1>
+      <button class="btn btn-primary" onclick="openAddTopicModal()">+ Add Topic</button>
+    </div>
+    <div id="project-view">
+      <div class="project-view-header">
+        <div class="project-view-title" id="project-view-title">Project: —</div>
+        <button class="btn btn-sm" onclick="closeProjectView()">&#10005; Close</button>
+      </div>
+      <div id="project-view-body"></div>
+    </div>
+    <div class="topics-filter">
+      <input type="search" id="topics-search" placeholder="Filter topics…" oninput="filterTopics(this.value)">
+    </div>
+    <div class="topics-subtabs">
+      <button class="subtab active" data-subtab="active" onclick="switchTopicsTab('active')">Active</button>
+      <button class="subtab" data-subtab="completed" onclick="switchTopicsTab('completed')">Completed</button>
+      <button class="subtab" data-subtab="archived" onclick="switchTopicsTab('archived')">Archived</button>
+    </div>
+    <div id="topics-active-wrap" class="table-wrap"></div>
+    <div id="topics-completed-wrap" class="table-wrap" style="display:none"></div>
+    <div id="topics-archived-wrap" class="table-wrap" style="display:none"></div>
+  </div>
+
+  <!-- ── Calendar ─────────────────────────────────────────────────── -->
+  <div id="tab-calendar" class="tab-panel">
+    <div class="cal-header">
+      <button class="btn btn-ghost btn-sm" onclick="changeMonth(-1)">&#8592;</button>
+      <div class="cal-month-label" id="cal-month-label">—</div>
+      <button class="btn btn-ghost btn-sm" onclick="changeMonth(1)">&#8594;</button>
+    </div>
+    <div id="cal-grid" class="cal-grid"></div>
+    <div id="cal-detail" class="cal-detail">
+      <div class="cal-detail-header">
+        <div class="cal-detail-title" id="cal-detail-date">—</div>
+        <button class="btn btn-ghost btn-sm" onclick="closeDayDetail()">✕ Close</button>
+      </div>
+      <div id="cal-detail-body" class="cal-detail-body"></div>
+    </div>
+  </div>
+
+  <!-- ── Projects ─────────────────────────────────────────────────── -->
+  <div id="tab-projects" class="tab-panel">
+
+    <!-- Projects list section -->
+    <div id="projects-list-section">
+      <div class="page-header">
+        <h1 class="page-title">Projects</h1>
+        <div class="toolbar">
+          <span style="font-size:12px;color:var(--muted)">Sort:</span>
+          <button id="sort-by-id" class="btn btn-sm btn-active" onclick="setProjectSort('id')">ID</button>
+          <button id="sort-by-name" class="btn btn-sm" onclick="setProjectSort('name')">Name</button>
+          <button class="btn btn-primary btn-sm" onclick="toggleNewProjectForm()">+ New Project</button>
+        </div>
+      </div>
+      <div id="new-project-form" class="new-project-form">
+        <div class="inline-form">
+          <div class="inline-field">
+            <label>Name</label>
+            <input id="np-name" type="text" placeholder="Project name">
+          </div>
+          <div class="inline-field">
+            <label>Description</label>
+            <input id="np-desc" type="text" placeholder="Optional description">
+          </div>
+          <button class="btn btn-primary btn-sm" onclick="createProject()">Add</button>
+          <button class="btn btn-sm" onclick="toggleNewProjectForm()">Cancel</button>
+        </div>
+      </div>
+      <div id="projects-table-wrap" class="table-wrap">
+        <div class="empty"><div class="spinner"></div></div>
+      </div>
+    </div>
+
+    <!-- Project detail section (shown when a project name is clicked) -->
+    <div id="project-detail-section" style="display:none">
+      <div class="page-header">
+        <div>
+          <button class="btn btn-sm" onclick="closeProjectDetail()" style="margin-bottom:8px">&#8592; Back to Projects</button>
+          <h1 class="page-title" id="pd-title">—</h1>
+        </div>
+      </div>
+      <div id="pd-description" style="color:var(--muted);font-size:13px;margin-bottom:16px"></div>
+      <div class="topics-subtabs">
+        <button class="subtab active" data-pdsubtab="active" onclick="switchProjectDetailTab('active')">Active</button>
+        <button class="subtab" data-pdsubtab="completed" onclick="switchProjectDetailTab('completed')">Completed</button>
+        <button class="subtab" data-pdsubtab="archived" onclick="switchProjectDetailTab('archived')">Archived</button>
+      </div>
+      <div id="pd-active-wrap" class="table-wrap"></div>
+      <div id="pd-completed-wrap" class="table-wrap" style="display:none"></div>
+      <div id="pd-archived-wrap" class="table-wrap" style="display:none"></div>
+    </div>
+
+  </div>
+
+  <!-- ── Stats ────────────────────────────────────────────────────── -->
+  <div id="tab-stats" class="tab-panel">
+    <div class="page-header">
+      <h1 class="page-title">Statistics</h1>
+    </div>
+    <div id="stats-grid" class="stats-grid">
+      <div class="empty"><div class="spinner"></div></div>
+    </div>
+    <div class="chart-card">
+      <div class="chart-header">
+        <div class="chart-title">Activity</div>
+        <div class="toolbar">
+          <span style="font-size:12px;color:var(--muted)">Range:</span>
+          <button class="btn btn-sm" id="chart-7" onclick="setChartDays(7)">7d</button>
+          <button class="btn btn-sm btn-active" id="chart-30" onclick="setChartDays(30)">30d</button>
+          <button class="btn btn-sm" id="chart-90" onclick="setChartDays(90)">90d</button>
+        </div>
+        <div class="chart-legend">
+          <div class="legend-item"><div class="legend-dot" style="background:#6366f1"></div>Added</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#22c55e"></div>Reviewed</div>
+        </div>
+      </div>
+      <div id="chart-container">
+        <div class="empty"><div class="spinner"></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Export ───────────────────────────────────────────────────── -->
+  <div id="tab-export" class="tab-panel">
+    <div class="page-header">
+      <h1 class="page-title">Export</h1>
+    </div>
+    <div class="export-section">
+      <h3>Download</h3>
+      <div class="toolbar">
+        <button class="btn" onclick="doExport('markdown')">⬇ Download Markdown</button>
+        <button class="btn" onclick="doExport('csv')">⬇ Download CSV</button>
+      </div>
+      <div class="export-preview">
+        <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin-bottom:6px;">Preview (Markdown)</div>
+        <pre id="export-preview">Loading…</pre>
+      </div>
+    </div>
+  </div>
+
+</main>
+
+<!-- ── Modal ──────────────────────────────────────────────────────── -->
+<div id="modal-backdrop" class="modal-backdrop" onclick="closeModalBackdrop(event)">
+  <div class="modal" id="modal-box">
+    <div id="modal-content"></div>
+  </div>
+</div>
+
+<!-- ── Toast ──────────────────────────────────────────────────────── -->
+<div id="toast"></div>
+
+<script>
+// ── Dark mode ──────────────────────────────────────────────────────────────
+function toggleDark() {
+  const isDark = document.body.classList.toggle('dark');
+  localStorage.setItem('spaced-dark', isDark ? '1' : '0');
+  document.getElementById('dark-toggle').textContent = isDark ? '☀️' : '🌙';
+  // Re-render chart with updated colors.
+  if (document.getElementById('tab-stats').classList.contains('active')) renderChart();
+}
+(function initDark() {
+  if (localStorage.getItem('spaced-dark') === '1') {
+    document.body.classList.add('dark');
+    document.getElementById('dark-toggle').textContent = '☀️';
+  }
+})();
+
+// ── State ──────────────────────────────────────────────────────────────────
+let calYear = new Date().getFullYear();
+let calMonth = new Date().getMonth() + 1;
+let calData = {};
+let projects = [];
+let projectSort = 'id';
+let chartDays = 30;
+let chartData = [];
+let currentTopicsTab = 'active';
+
+// ── API ────────────────────────────────────────────────────────────────────
+async function api(method, path, body) {
+  const opts = { method, headers: {} };
+  if (body !== undefined) {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(body);
+  }
+  const res = await fetch(path, opts);
+  if (res.headers.get('content-type')?.includes('application/json')) {
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Request failed');
+    return data;
+  }
+  if (!res.ok) throw new Error('Request failed');
+  return res;
+}
+
+// ── Toast ──────────────────────────────────────────────────────────────────
+let toastTimer;
+function toast(msg, isError) {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.className = isError ? 'show error' : 'show';
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => { el.className = ''; }, 3000);
+}
+
+// ── Tab routing ────────────────────────────────────────────────────────────
+const tabLoaders = {
+  review: loadReview,
+  topics: loadTopics,
+  calendar: () => renderCalendar(calYear, calMonth),
+  projects: loadProjects,
+  stats: loadStats,
+  export: loadExport,
+};
+
+document.querySelectorAll('.nav-tab').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.nav-tab').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    btn.classList.add('active');
+    const tabId = btn.dataset.tab;
+    document.getElementById('tab-' + tabId).classList.add('active');
+    closeDayDetail();
+    tabLoaders[tabId]?.();
+  });
+});
+
+// ── Review Queue ───────────────────────────────────────────────────────────
+async function loadReview() {
+  const el = document.getElementById('review-list');
+  el.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  try {
+    const topics = await api('GET', '/api/topics/review');
+    const countEl = document.getElementById('review-count');
+    if (topics.length > 0) { countEl.textContent = topics.length; countEl.style.display = ''; }
+    else countEl.style.display = 'none';
+
+    el.innerHTML = '';
+    if (topics.length === 0) {
+      el.innerHTML = '<div class="empty"><div class="empty-icon">✅</div><div class="empty-text">Nothing due for review today!</div></div>';
+      return;
+    }
+
+    // Group by date, sort groups latest-first (most recent overdue first).
+    const groups = {};
+    topics.forEach(t => {
+      const d = t.next_review_at.slice(0, 10);
+      if (!groups[d]) groups[d] = [];
+      groups[d].push(t);
+    });
+    const sortedDates = Object.keys(groups).sort().reverse();
+
+    const today = new Date().toISOString().slice(0, 10);
+    sortedDates.forEach(date => {
+      const grpTopics = groups[date];
+      const hdr = document.createElement('div');
+      hdr.className = 'group-header';
+      const label = date === today ? 'Today' : formatDate(date + 'T00:00:00');
+      hdr.innerHTML = `<span class="group-date-label">${label}</span><span class="group-count">${grpTopics.length}</span>`;
+      el.appendChild(hdr);
+      grpTopics.forEach(t => el.appendChild(makeReviewCard(t)));
+    });
+  } catch(e) { el.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+}
+
+function makeReviewCard(t) {
+  const div = document.createElement('div');
+  div.className = 'card';
+  div.id = 'card-' + t.id;
+  const schedulingMode = t.interval_days > 0 ? 'SM-2' : 'Fixed';
+  div.innerHTML = `
+    <div class="card-body">${esc(t.topic)}</div>
+    <div class="card-meta">
+      <span class="chip chip-primary">${esc(t.project_name || 'UNASSIGNED')}</span>
+      <span class="chip">Day ${t.review_day}</span>
+      <span class="chip">${schedulingMode}</span>
+      ${t.notes ? `<span class="chip">${esc(t.notes.slice(0,40))}${t.notes.length>40?'…':''}</span>` : ''}
+    </div>
+    <div class="card-actions">
+      <button class="btn btn-primary btn-sm" onclick="markDone(${t.id}, null, 'card-${t.id}')">Done (Fixed)</button>
+      <button class="btn btn-sm" onclick="toggleQualityPicker(${t.id})">Done (SM-2) ▾</button>
+      <input type="number" id="snooze-days-${t.id}" value="1" min="1" max="365" style="width:52px;padding:3px 6px;border:1px solid var(--border);border-radius:6px;font-size:12px;background:var(--bg);color:var(--text)">
+      <button class="btn btn-sm" onclick="snooze(${t.id}, parseInt(document.getElementById('snooze-days-${t.id}').value)||1, 'card-${t.id}')">Snooze</button>
+    </div>
+    <div class="quality-picker" id="qp-${t.id}">
+      <span>Quality:</span>
+      ${[0,1,2,3,4,5].map(q => `<button class="btn btn-sm q-btn" onclick="markDone(${t.id},${q},'card-${t.id}')" title="${qualityLabel(q)}">${q}</button>`).join('')}
+      <span style="font-size:10px;color:var(--muted)">(0=blackout, 5=perfect)</span>
+    </div>`;
+  return div;
+}
+
+function qualityLabel(q) {
+  return ['Blackout','Incorrect (hard)','Incorrect (easy)','Correct (hard)','Correct (hesitation)','Perfect'][q];
+}
+
+function toggleQualityPicker(id) {
+  document.getElementById('qp-' + id).classList.toggle('open');
+}
+
+async function markDone(id, quality, cardId) {
+  const body = quality !== null ? { quality } : {};
+  try {
+    await api('PUT', `/api/topics/${id}/done`, body);
+    const card = document.getElementById(cardId);
+    if (card) {
+      card.style.transition = 'opacity .3s, max-height .3s';
+      card.style.opacity = '0';
+      setTimeout(() => { card.remove(); updateReviewCount(); }, 300);
+    }
+    toast('Marked done ✓');
+  } catch(e) { toast(e.message, true); }
+}
+
+async function snooze(id, days, cardId) {
+  try {
+    await api('PUT', `/api/topics/${id}/snooze`, { days });
+    const card = document.getElementById(cardId);
+    if (card) { card.style.transition = 'opacity .3s'; card.style.opacity = '0';
+                setTimeout(() => { card.remove(); updateReviewCount(); }, 300); }
+    toast(`Snoozed ${days}d`);
+  } catch(e) { toast(e.message, true); }
+}
+
+function updateReviewCount() {
+  const remaining = document.querySelectorAll('#review-list .card').length;
+  const countEl = document.getElementById('review-count');
+  if (remaining > 0) { countEl.textContent = remaining; countEl.style.display = ''; }
+  else {
+    countEl.style.display = 'none';
+    // Remove leftover group headers too.
+    const el = document.getElementById('review-list');
+    if (!el.querySelector('.card')) {
+      el.innerHTML = '<div class="empty"><div class="empty-icon">✅</div><div class="empty-text">All done for today!</div></div>';
+    }
+  }
+}
+
+// ── All Topics ─────────────────────────────────────────────────────────────
+function loadTopics() { switchTopicsTab(currentTopicsTab); }
+
+function switchTopicsTab(tab) {
+  currentTopicsTab = tab;
+  const searchEl = document.getElementById('topics-search');
+  if (searchEl) searchEl.value = '';
+  document.querySelectorAll('.subtab').forEach(b =>
+    b.classList.toggle('active', b.dataset.subtab === tab));
+  ['active','completed','archived'].forEach(t => {
+    document.getElementById(`topics-${t}-wrap`).style.display = t === tab ? '' : 'none';
+  });
+  loadTopicsTab(tab);
+}
+
+function filterTopics(query) {
+  const q = query.toLowerCase();
+  const wrap = document.getElementById(`topics-${currentTopicsTab}-wrap`);
+  wrap?.querySelectorAll('tr[data-filter]').forEach(row => {
+    row.style.display = q && !row.dataset.filter.toLowerCase().includes(q) ? 'none' : '';
+  });
+}
+
+async function loadTopicsTab(tab) {
+  const wrap = document.getElementById(`topics-${tab}-wrap`);
+  wrap.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  const params = new URLSearchParams();
+  if (tab === 'completed') params.set('completed', 'true');
+  if (tab === 'archived')  params.set('archived', 'true');
+  try {
+    await loadProjectsIfNeeded();
+    const topics = await api('GET', '/api/topics?' + params);
+    wrap.innerHTML = topics.length
+      ? renderTopicsTable(topics, tab)
+      : '<div class="empty"><div class="empty-text">No topics here.</div></div>';
+  } catch(e) { wrap.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+}
+
+function renderTopicsTable(topics, tab) {
+  const rows = topics.map(t => {
+    const overdue = tab === 'active' && isTopicOverdue(t);
+    const rowClass = overdue ? 'overdue' : '';
+    const projName = esc(t.project_name || 'UNASSIGNED');
+    const projectCell = t.project_id !== null
+      ? `<span class="project-link" onclick="openProjectView(${t.project_id}, '${projName.replace(/'/g,"\\'")}')"><span class="chip chip-primary">${projName}</span></span>`
+      : `<span class="chip chip-primary">${projName}</span>`;
+    return `<tr class="${rowClass}" data-filter="${esc(t.topic + ' ' + (t.notes || ''))}">
+      <td><div class="topic-text">${esc(t.topic)}</div>${t.notes ? `<div class="notes-text">${esc(t.notes)}</div>` : ''}</td>
+      <td>${projectCell}</td>
+      <td>${formatDate(t.next_review_at)}</td>
+      <td>Day ${t.review_day}</td>
+      <td>${statusChip(t)}</td>
+      <td>
+        <div style="display:flex;gap:4px;flex-wrap:wrap">
+          <button class="btn btn-ghost btn-sm" onclick="openEditModal(${t.id})">Edit</button>
+          ${t.parked
+            ? `<button class="btn btn-ghost btn-sm" style="color:var(--primary)" onclick="openOnboardModal(${t.id}, ${t.review_cycle})">Onboard</button>`
+            : `<button class="btn btn-ghost btn-sm" onclick="offboardTopic(${t.id})">Offboard</button>`}
+          ${t.archived
+            ? `<button class="btn btn-ghost btn-sm" onclick="unarchiveTopic(${t.id})">Unarchive</button>`
+            : `<button class="btn btn-ghost btn-sm" onclick="archiveTopic(${t.id})">Archive</button>`}
+          <button class="btn btn-ghost btn-sm" style="color:var(--red)" onclick="deleteTopic(${t.id})">Delete</button>
+        </div>
+      </td>
+    </tr>`;
+  }).join('');
+  return `<table>
+    <thead><tr><th>Topic</th><th>Project</th><th>Next Review</th><th>Cycle</th><th>Status</th><th>Actions</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+}
+
+async function openProjectView(projectId, projectName) {
+  const view = document.getElementById('project-view');
+  document.getElementById('project-view-title').textContent = `Project: ${projectName}`;
+  const body = document.getElementById('project-view-body');
+  body.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  view.classList.add('open');
+  setTimeout(() => view.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 50);
+  try {
+    const [active, archived] = await Promise.all([
+      api('GET', `/api/topics?project_id=${projectId}`),
+      api('GET', `/api/topics?project_id=${projectId}&archived=true`),
+    ]);
+    const topics = [...active, ...archived];
+    if (topics.length === 0) {
+      body.innerHTML = '<div class="empty"><div class="empty-text">No topics in this project.</div></div>';
+      return;
+    }
+    const rows = topics.map(t => {
+      const overdue = isTopicOverdue(t);
+      const rowClass = overdue ? 'overdue' : (t.completed ? 'completed' : '');
+      return `<tr class="${rowClass}">
+        <td><div class="topic-text">${esc(t.topic)}</div>${t.notes ? `<div class="notes-text">${esc(t.notes)}</div>` : ''}</td>
+        <td>${formatDate(t.next_review_at)}</td>
+        <td>${statusChip(t)}</td>
+      </tr>`;
+    }).join('');
+    body.innerHTML = `<div class="table-wrap"><table>
+      <thead><tr><th>Topic</th><th>Next Review</th><th>Status</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table></div>`;
+  } catch(e) { body.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+}
+
+function closeProjectView() {
+  document.getElementById('project-view').classList.remove('open');
+}
+
+function statusChip(t) {
+  if (t.archived) return '<span class="chip">Archived</span>';
+  if (t.completed) return '<span class="chip chip-green">Completed</span>';
+  if (t.parked) return '<span class="chip" style="background:var(--amber-bg);color:var(--amber);border-color:#fcd34d">Parked</span>';
+  if (isTopicOverdue(t)) return '<span class="chip" style="background:var(--red-bg);color:var(--red);border-color:#fca5a5">Overdue</span>';
+  return '<span class="chip">Active</span>';
+}
+
+async function archiveTopic(id) {
+  try { await api('PUT', `/api/topics/${id}/archive`); toast('Archived'); loadTopics(); }
+  catch(e) { toast(e.message, true); }
+}
+async function unarchiveTopic(id) {
+  try { await api('PUT', `/api/topics/${id}/unarchive`); toast('Unarchived'); loadTopics(); }
+  catch(e) { toast(e.message, true); }
+}
+async function deleteTopic(id) {
+  if (!confirm('Delete this topic? This cannot be undone.')) return;
+  try { await api('DELETE', `/api/topics/${id}`); toast('Deleted'); loadTopics(); }
+  catch(e) { toast(e.message, true); }
+}
+
+async function offboardTopic(id) {
+  try { await api('PUT', `/api/topics/${id}/park`); toast('Topic offboarded'); loadTopics(); }
+  catch(e) { toast(e.message, true); }
+}
+
+function openOnboardModal(id, currentCycle) {
+  const content = `
+    <div class="modal-title">Onboard Topic</div>
+    <p style="color:var(--muted);margin-bottom:16px;font-size:13px">
+      Return this topic to the revision cycle. It will be immediately due for review.
+    </p>
+    <div class="field">
+      <label>Start from cycle stage (0–6)</label>
+      <input id="ob-cycle" type="number" min="0" max="6" value="${currentCycle}"
+             style="width:100px">
+      <div style="font-size:12px;color:var(--muted);margin-top:4px">
+        Current stage: ${currentCycle} &nbsp;·&nbsp; Leave unchanged to resume where you left off.
+      </div>
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="submitOnboard(${id}, ${currentCycle})">Onboard</button>
+    </div>`;
+  openModal(content);
+}
+
+async function submitOnboard(id, originalCycle) {
+  const inputCycle = parseInt(document.getElementById('ob-cycle').value, 10);
+  if (isNaN(inputCycle) || inputCycle < 0 || inputCycle > 6) {
+    toast('Cycle must be 0–6', true); return;
+  }
+  const body = inputCycle !== originalCycle ? { cycle: inputCycle } : {};
+  try {
+    await api('PUT', `/api/topics/${id}/onboard`, body);
+    toast('Topic onboarded ✓'); closeModal(); loadTopics();
+  } catch(e) { toast(e.message, true); }
+}
+
+// ── Add Topic Modal ────────────────────────────────────────────────────────
+function openAddTopicModal() {
+  const todayISO = localTodayStr();
+  const content = `
+    <div class="modal-title">Add Topic</div>
+    <div class="field"><label>Topic *</label><input id="m-topic" type="text" placeholder="What to learn?"></div>
+    <div class="field"><label>Notes</label><textarea id="m-notes" placeholder="Optional context or notes"></textarea></div>
+    <div class="field"><label>Project</label>
+      <select id="m-project">
+        <option value="">UNASSIGNED</option>
+        ${projects.map(p => `<option value="${esc(p.name)}">${esc(p.name)}</option>`).join('')}
+      </select>
+    </div>
+    <div class="field"><label>First Review Date <span style="font-weight:normal;color:var(--muted)">(optional, defaults to today)</span></label>
+      <input id="m-review-date" type="date" value="${todayISO}">
+    </div>
+    <div class="field" style="display:flex;align-items:center;gap:8px">
+      <input type="checkbox" id="m-onboard" style="width:auto;margin:0">
+      <label for="m-onboard" style="margin:0;font-weight:normal">Onboard to Revision Cycle</label>
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="submitAddTopic()">Add</button>
+    </div>`;
+  openModal(content);
+  setTimeout(() => document.getElementById('m-topic')?.focus(), 50);
+}
+
+async function submitAddTopic() {
+  const topic = document.getElementById('m-topic').value.trim();
+  if (!topic) { toast('Topic is required', true); return; }
+  const notes = document.getElementById('m-notes').value.trim();
+  const project_name = document.getElementById('m-project').value || 'UNASSIGNED';
+  const parked = !document.getElementById('m-onboard').checked;
+  const reviewDateVal = document.getElementById('m-review-date').value;
+  const review_date = reviewDateVal && reviewDateVal !== localTodayStr() ? reviewDateVal : undefined;
+  try {
+    await api('POST', '/api/topics', { topic, notes, project_name, parked, ...(review_date ? { review_date } : {}) });
+    toast(parked ? 'Topic parked ✓' : 'Topic added to revision cycle ✓');
+    closeModal(); loadTopics();
+  } catch(e) { toast(e.message, true); }
+}
+
+// ── Edit Topic Modal ───────────────────────────────────────────────────────
+async function openEditModal(id) {
+  try {
+    const [active, archived] = await Promise.all([
+      api('GET', '/api/topics'),
+      api('GET', '/api/topics?archived=true'),
+    ]);
+    const t = [...active, ...archived].find(x => x.id === id);
+    if (!t) { toast('Topic not found', true); return; }
+    const content = `
+      <div class="modal-title">Edit Topic</div>
+      <div class="field"><label>Topic</label><input id="e-topic" type="text" value="${esc(t.topic)}"></div>
+      <div class="field"><label>Notes</label><textarea id="e-notes">${esc(t.notes || '')}</textarea></div>
+      <div class="field"><label>Review Cycle (0–6)</label>
+        <input id="e-cycle" type="number" min="0" max="6" value="${t.review_cycle}"></div>
+      <div class="field"><label>Project</label>
+        <select id="e-project">
+          <option value="">UNASSIGNED</option>
+          ${projects.map(p => `<option value="${p.id}" ${t.project_id == p.id ? 'selected' : ''}>${esc(p.name)}</option>`).join('')}
+        </select>
+      </div>
+      <div class="modal-actions">
+        <button class="btn" onclick="closeModal()">Cancel</button>
+        <button class="btn btn-primary" onclick="submitEditTopic(${id})">Save</button>
+      </div>`;
+    openModal(content);
+  } catch(e) { toast(e.message, true); }
+}
+
+async function submitEditTopic(id) {
+  const body = {};
+  const topic = document.getElementById('e-topic').value.trim();
+  const notes = document.getElementById('e-notes').value.trim();
+  const cycle = parseInt(document.getElementById('e-cycle').value, 10);
+  const projectId = document.getElementById('e-project').value;
+  if (topic) body.topic = topic;
+  body.notes = notes;
+  if (!isNaN(cycle)) body.review_cycle = cycle;
+  if (projectId) body.project_id = parseInt(projectId, 10);
+  try {
+    await api('PUT', `/api/topics/${id}/modify`, body);
+    toast('Saved ✓'); closeModal(); loadTopics();
+  } catch(e) { toast(e.message, true); }
+}
+
+// ── Calendar ───────────────────────────────────────────────────────────────
+function changeMonth(delta) {
+  calMonth += delta;
+  if (calMonth > 12) { calMonth = 1; calYear++; }
+  if (calMonth < 1)  { calMonth = 12; calYear--; }
+  closeDayDetail();
+  renderCalendar(calYear, calMonth);
+}
+
+const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+const DAYS = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+async function renderCalendar(year, month) {
+  document.getElementById('cal-month-label').textContent = `${MONTHS[month-1]} ${year}`;
+  const grid = document.getElementById('cal-grid');
+  grid.innerHTML = DAYS.map(d => `<div class="cal-dow">${d}</div>`).join('');
+
+  try {
+    const days = await api('GET', `/api/calendar?year=${year}&month=${month}`);
+    calData = {};
+    days.forEach(d => { calData[d.date] = d; });
+  } catch(e) { toast(e.message, true); return; }
+
+  const firstDay = new Date(year, month - 1, 1).getDay();
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const todayStr = new Date().toISOString().slice(0, 10);
+
+  for (let i = 0; i < firstDay; i++) {
+    const cell = document.createElement('div');
+    cell.className = 'cal-cell other-month';
+    grid.appendChild(cell);
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${year}-${String(month).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+    const dayData = calData[dateStr];
+    const cell = document.createElement('div');
+    cell.className = 'cal-cell' + (dateStr === todayStr ? ' today' : '') + (dayData ? ' has-tasks' : '');
+    cell.dataset.date = dateStr;
+    let dots = '';
+    if (dayData) {
+      if (dayData.pending > 0)   dots += `<div class="dot dot-red" title="${dayData.pending} pending"></div>`;
+      if (dayData.completed > 0) dots += `<div class="dot dot-green" title="${dayData.completed} completed"></div>`;
+    }
+    cell.innerHTML = `<div class="cal-day-num">${d}</div><div class="cal-dots">${dots}</div>`;
+    if (dayData) {
+      cell.addEventListener('click', () => openDayDetail(dateStr, dayData, cell));
+    }
+    grid.appendChild(cell);
+  }
+}
+
+function openDayDetail(dateStr, dayData, cell) {
+  // Toggle: clicking the same cell closes the panel.
+  const detail = document.getElementById('cal-detail');
+  const prevSelected = document.querySelector('.cal-cell.selected');
+  if (prevSelected) prevSelected.classList.remove('selected');
+
+  if (detail.classList.contains('open') && detail.dataset.activeDate === dateStr) {
+    closeDayDetail();
+    return;
+  }
+
+  cell.classList.add('selected');
+  detail.dataset.activeDate = dateStr;
+  document.getElementById('cal-detail-date').textContent = formatDate(dateStr + 'T00:00:00');
+  const body = document.getElementById('cal-detail-body');
+  body.innerHTML = '';
+
+  if (!dayData?.topics?.length) {
+    body.innerHTML = '<div class="empty" style="padding:20px"><div class="empty-text">No topics for this date.</div></div>';
+  } else {
+    dayData.topics.forEach(t => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      card.id = 'dp-card-' + t.id;
+      const isDone = t.completed;
+      card.innerHTML = `
+        <div class="card-body" style="${isDone ? 'color:var(--muted)' : ''}">${esc(t.topic)}</div>
+        <div class="card-meta">
+          <span class="chip chip-primary">${esc(t.project_name || 'UNASSIGNED')}</span>
+          ${isDone ? '<span class="chip chip-green">Completed</span>' : `<span class="chip">Day ${t.review_day}</span>`}
+        </div>
+        ${!isDone ? `<div class="card-actions">
+          <button class="btn btn-primary btn-sm" onclick="markDoneFromDetail(${t.id}, null)">Done (Fixed)</button>
+          <button class="btn btn-sm" onclick="toggleDetailQualityPicker(${t.id})">Done (SM-2) ▾</button>
+          <input type="number" id="dp-snooze-days-${t.id}" value="1" min="1" max="365" style="width:52px;padding:3px 6px;border:1px solid var(--border);border-radius:6px;font-size:12px;background:var(--bg);color:var(--text)">
+          <button class="btn btn-sm" onclick="snoozeFromDetail(${t.id})">Snooze</button>
+        </div>
+        <div class="quality-picker" id="dqp-${t.id}">
+          <span>Quality:</span>
+          ${[0,1,2,3,4,5].map(q => `<button class="btn btn-sm q-btn" onclick="markDoneFromDetail(${t.id},${q})" title="${qualityLabel(q)}">${q}</button>`).join('')}
+          <span style="font-size:10px;color:var(--muted)">(0=blackout, 5=perfect)</span>
+        </div>` : ''}`;
+      body.appendChild(card);
+    });
+  }
+  detail.classList.add('open');
+  // Scroll so the detail panel is visible.
+  setTimeout(() => detail.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 50);
+}
+
+async function markDoneFromDetail(id, quality) {
+  const body = quality !== null && quality !== undefined ? { quality } : {};
+  try {
+    await api('PUT', `/api/topics/${id}/done`, body);
+    toast('Marked done ✓');
+    document.getElementById('dp-card-' + id)?.remove();
+    renderCalendar(calYear, calMonth);
+  } catch(e) { toast(e.message, true); }
+}
+
+function toggleDetailQualityPicker(id) {
+  document.getElementById('dqp-' + id).classList.toggle('open');
+}
+
+async function snoozeFromDetail(id) {
+  const daysInput = document.getElementById('dp-snooze-days-' + id);
+  const days = parseInt(daysInput?.value) || 1;
+  try {
+    await api('PUT', `/api/topics/${id}/snooze`, { days });
+    toast(`Snoozed ${days}d`);
+    document.getElementById('dp-card-' + id)?.remove();
+    renderCalendar(calYear, calMonth);
+  } catch(e) { toast(e.message, true); }
+}
+
+function closeDayDetail() {
+  const detail = document.getElementById('cal-detail');
+  detail.classList.remove('open');
+  detail.dataset.activeDate = '';
+  document.querySelector('.cal-cell.selected')?.classList.remove('selected');
+}
+
+// ── Projects ───────────────────────────────────────────────────────────────
+function setProjectSort(by) {
+  projectSort = by;
+  document.getElementById('sort-by-id').className = 'btn btn-sm' + (by === 'id' ? ' btn-active' : '');
+  document.getElementById('sort-by-name').className = 'btn btn-sm' + (by === 'name' ? ' btn-active' : '');
+  loadProjects();
+}
+
+async function loadProjectsIfNeeded() {
+  if (projects.length === 0) await loadProjectsData();
+}
+
+async function loadProjectsData() {
+  try { projects = await api('GET', '/api/projects'); }
+  catch(e) { projects = []; }
+}
+
+async function loadProjects() {
+  const wrap = document.getElementById('projects-table-wrap');
+  wrap.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  try {
+    await loadProjectsData();
+    let sorted = [...projects];
+    if (projectSort === 'name') sorted.sort((a, b) => a.name.localeCompare(b.name));
+    else sorted.sort((a, b) => a.id - b.id);
+
+    if (sorted.length === 0) {
+      wrap.innerHTML = '<div class="empty"><div class="empty-text">No projects yet.</div></div>';
+      return;
+    }
+    const rows = sorted.map(p => `<tr>
+      <td>${p.id}</td>
+      <td><span class="project-link" style="color:var(--primary);font-weight:600" onclick="openProjectDetail(${p.id}, '${esc(p.name).replace(/'/g,"\\'")}', '${esc(p.description||'').replace(/'/g,"\\'")}')"><u>${esc(p.name)}</u></span></td>
+      <td>${esc(p.description || '')}</td>
+      <td>
+        <div style="display:flex;gap:4px">
+          <button class="btn btn-ghost btn-sm" onclick="openRenameProject(${p.id}, '${esc(p.name).replace(/'/g,"\\'")}')">Rename</button>
+          <button class="btn btn-ghost btn-sm" onclick="openDescribeProject(${p.id}, '${esc(p.description || '').replace(/'/g,"\\'")}')">Description</button>
+          <button class="btn btn-ghost btn-sm" style="color:var(--red)" onclick="deleteProject(${p.id})">Delete</button>
+        </div>
+      </td>
+    </tr>`).join('');
+    wrap.innerHTML = `<table>
+      <thead><tr><th>ID</th><th>Name</th><th>Description</th><th>Actions</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  } catch(e) { wrap.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+}
+
+// ── Project detail view ────────────────────────────────────────────────────
+let currentProjectDetailId = null;
+let currentProjectDetailTab = 'active';
+
+function openProjectDetail(id, name, description) {
+  currentProjectDetailId = id;
+  currentProjectDetailTab = 'active';
+  document.getElementById('pd-title').textContent = name;
+  const descEl = document.getElementById('pd-description');
+  if (description) { descEl.textContent = description; descEl.style.display = ''; }
+  else descEl.style.display = 'none';
+  document.getElementById('projects-list-section').style.display = 'none';
+  document.getElementById('project-detail-section').style.display = '';
+  // reset subtabs
+  document.querySelectorAll('[data-pdsubtab]').forEach(b =>
+    b.classList.toggle('active', b.dataset.pdsubtab === 'active'));
+  ['active','completed','archived'].forEach(t =>
+    document.getElementById(`pd-${t}-wrap`).style.display = t === 'active' ? '' : 'none');
+  loadProjectDetailTab('active');
+}
+
+function closeProjectDetail() {
+  document.getElementById('project-detail-section').style.display = 'none';
+  document.getElementById('projects-list-section').style.display = '';
+  loadProjects();
+}
+
+function switchProjectDetailTab(tab) {
+  currentProjectDetailTab = tab;
+  document.querySelectorAll('[data-pdsubtab]').forEach(b =>
+    b.classList.toggle('active', b.dataset.pdsubtab === tab));
+  ['active','completed','archived'].forEach(t =>
+    document.getElementById(`pd-${t}-wrap`).style.display = t === tab ? '' : 'none');
+  loadProjectDetailTab(tab);
+}
+
+async function loadProjectDetailTab(tab) {
+  const wrap = document.getElementById(`pd-${tab}-wrap`);
+  wrap.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  const params = new URLSearchParams({ project_id: currentProjectDetailId });
+  if (tab === 'completed') params.set('completed', 'true');
+  if (tab === 'archived')  params.set('archived', 'true');
+  try {
+    const topics = await api('GET', '/api/topics?' + params);
+    wrap.innerHTML = topics.length
+      ? renderTopicsTable(topics, tab)
+      : '<div class="empty"><div class="empty-text">No topics here.</div></div>';
+  } catch(e) { wrap.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+}
+
+function toggleNewProjectForm() {
+  document.getElementById('new-project-form').classList.toggle('open');
+}
+
+async function createProject() {
+  const name = document.getElementById('np-name').value.trim();
+  const description = document.getElementById('np-desc').value.trim();
+  if (!name) { toast('Name is required', true); return; }
+  try {
+    await api('POST', '/api/projects', { name, description });
+    toast('Project created ✓');
+    document.getElementById('np-name').value = '';
+    document.getElementById('np-desc').value = '';
+    toggleNewProjectForm();
+    loadProjects();
+  } catch(e) { toast(e.message, true); }
+}
+
+function openRenameProject(id, currentName) {
+  const content = `
+    <div class="modal-title">Rename Project</div>
+    <div class="field"><label>New Name</label><input id="r-name" type="text" value="${esc(currentName)}"></div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="submitRenameProject(${id})">Rename</button>
+    </div>`;
+  openModal(content);
+  setTimeout(() => document.getElementById('r-name')?.focus(), 50);
+}
+
+async function submitRenameProject(id) {
+  const name = document.getElementById('r-name').value.trim();
+  if (!name) { toast('Name is required', true); return; }
+  try {
+    await api('PUT', `/api/projects/${id}/rename`, { name });
+    toast('Renamed ✓'); closeModal(); loadProjects();
+  } catch(e) { toast(e.message, true); }
+}
+
+function openDescribeProject(id, currentDesc) {
+  const content = `
+    <div class="modal-title">Edit Description</div>
+    <div class="field"><label>Description</label><textarea id="d-desc">${esc(currentDesc)}</textarea></div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="submitDescribeProject(${id})">Save</button>
+    </div>`;
+  openModal(content);
+}
+
+async function submitDescribeProject(id) {
+  const description = document.getElementById('d-desc').value.trim();
+  try {
+    await api('PUT', `/api/projects/${id}/describe`, { description });
+    toast('Saved ✓'); closeModal(); loadProjects();
+  } catch(e) { toast(e.message, true); }
+}
+
+async function deleteProject(id) {
+  if (!confirm('Delete this project? Topics in it will become unassigned.')) return;
+  try {
+    await api('DELETE', `/api/projects/${id}`);
+    toast('Deleted'); loadProjects();
+  } catch(e) { toast(e.message, true); }
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+async function loadStats() {
+  const grid = document.getElementById('stats-grid');
+  grid.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  try {
+    const s = await api('GET', '/api/stats');
+    const pct = s.Total > 0 ? Math.round(s.Completed / s.Total * 100) : 0;
+    grid.innerHTML = `
+      ${statCard(s.Total, 'Total Topics', '')}
+      ${statCard(s.Completed, 'Completed', 'good')}
+      ${statCard(s.InProgress, 'In Progress', 'primary')}
+      ${s.Parked > 0 ? statCard(s.Parked, 'Parked', '') : ''}
+      ${statCard(s.DueToday, 'Due Today', s.DueToday > 0 ? 'warn' : '')}
+      ${statCard(s.Overdue, 'Overdue', s.Overdue > 0 ? 'danger' : '')}
+      ${statCard(s.Archived, 'Archived', '')}
+      ${statCard(s.Projects, 'Projects', '')}
+      ${statCard(pct + '%', 'Completion', pct >= 80 ? 'good' : pct >= 40 ? 'warn' : '')}`;
+  } catch(e) { grid.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+  await loadChart(chartDays);
+}
+
+function statCard(value, label, cls) {
+  return `<div class="stat-card ${cls}"><div class="stat-value">${value}</div><div class="stat-label">${label}</div></div>`;
+}
+
+async function setChartDays(days) {
+  chartDays = days;
+  ['7','30','90'].forEach(d => {
+    const btn = document.getElementById('chart-' + d);
+    btn.className = 'btn btn-sm' + (d == days ? ' btn-active' : '');
+  });
+  await loadChart(days);
+}
+
+async function loadChart(days) {
+  const container = document.getElementById('chart-container');
+  container.innerHTML = '<div class="empty"><div class="spinner"></div></div>';
+  try {
+    chartData = await api('GET', `/api/stats/history?days=${days}`);
+    renderChart();
+  } catch(e) { container.innerHTML = `<div class="empty" style="color:var(--red)">${e.message}</div>`; }
+}
+
+function renderChart() {
+  const container = document.getElementById('chart-container');
+  if (!chartData || chartData.length === 0) {
+    container.innerHTML = '<div class="empty"><div class="empty-text">No activity data yet.</div></div>';
+    return;
+  }
+
+  const isDark = document.body.classList.contains('dark');
+  const textColor = isDark ? '#94a3b8' : '#64748b';
+  const gridColor = isDark ? '#334155' : '#e2e8f0';
+  const surfaceColor = isDark ? '#1e293b' : '#ffffff';
+  const PRIMARY = '#6366f1';
+  const GREEN = '#22c55e';
+
+  const W = 760, H = 200, PL = 42, PR = 16, PT = 12, PB = 38;
+  const cW = W - PL - PR;
+  const cH = H - PT - PB;
+  const n = chartData.length;
+  const maxVal = Math.max(1, ...chartData.map(d => Math.max(d.added, d.reviewed)));
+
+  const xPos = i => PL + (n <= 1 ? cW / 2 : (i / (n - 1)) * cW);
+  const yPos = v => PT + cH - Math.round((v / maxVal) * cH);
+
+  // Y grid lines at 0, 25%, 50%, 75%, 100%
+  const yTicks = [0, .25, .5, .75, 1].map(f => Math.round(f * maxVal));
+  const gridSVG = yTicks.map(v => {
+    const y = yPos(v);
+    return `<line x1="${PL}" y1="${y}" x2="${W - PR}" y2="${y}" stroke="${gridColor}" stroke-width="1"/>
+            <text x="${PL - 5}" y="${y + 4}" text-anchor="end" font-size="10" fill="${textColor}" font-family="system-ui">${v}</text>`;
+  }).join('');
+
+  // X axis labels — show ~7 labels max
+  const step = Math.max(1, Math.floor(n / 7));
+  const xLabelSVG = chartData.map((d, i) => {
+    if (i % step !== 0 && i !== n - 1) return '';
+    return `<text x="${xPos(i)}" y="${H - 6}" text-anchor="middle" font-size="10" fill="${textColor}" font-family="system-ui">${d.date.slice(5)}</text>`;
+  }).join('');
+
+  // Area paths
+  const areaPath = (key) => {
+    const pts = chartData.map((d, i) => `${xPos(i)},${yPos(d[key])}`).join(' L ');
+    return `M ${xPos(0)},${PT + cH} L ${pts} L ${xPos(n - 1)},${PT + cH} Z`;
+  };
+  const linePts = (key) => chartData.map((d, i) => `${xPos(i)},${yPos(d[key])}`).join(' ');
+
+  // Dots for small datasets
+  const dotsSVG = n <= 20 ? chartData.flatMap((d, i) => [
+    d.added > 0 ? `<circle cx="${xPos(i)}" cy="${yPos(d.added)}" r="3" fill="${PRIMARY}" stroke="${surfaceColor}" stroke-width="1.5"/>` : '',
+    d.reviewed > 0 ? `<circle cx="${xPos(i)}" cy="${yPos(d.reviewed)}" r="3" fill="${GREEN}" stroke="${surfaceColor}" stroke-width="1.5"/>` : '',
+  ]).join('') : '';
+
+  container.innerHTML = `<svg viewBox="0 0 ${W} ${H}" style="width:100%;display:block" aria-label="Activity chart">
+    <rect x="${PL}" y="${PT}" width="${cW}" height="${cH}" fill="${surfaceColor}"/>
+    ${gridSVG}
+    <path d="${areaPath('added')}" fill="${PRIMARY}" opacity="0.12"/>
+    <path d="${areaPath('reviewed')}" fill="${GREEN}" opacity="0.12"/>
+    <polyline points="${linePts('added')}" fill="none" stroke="${PRIMARY}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+    <polyline points="${linePts('reviewed')}" fill="none" stroke="${GREEN}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+    ${dotsSVG}
+    ${xLabelSVG}
+  </svg>`;
+}
+
+// ── Export ─────────────────────────────────────────────────────────────────
+async function loadExport() {
+  const pre = document.getElementById('export-preview');
+  pre.textContent = 'Loading…';
+  try {
+    const res = await fetch('/api/export?format=markdown');
+    const text = await res.text();
+    pre.textContent = text.slice(0, 3000) + (text.length > 3000 ? '\n…(truncated)' : '');
+  } catch(e) { pre.textContent = 'Error: ' + e.message; }
+}
+
+async function doExport(format) {
+  try {
+    const res = await fetch(`/api/export?format=${format}`);
+    if (!res.ok) { toast('Export failed', true); return; }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = format === 'csv' ? 'spaced-export.csv' : 'spaced-export.md';
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    toast('Downloaded ✓');
+  } catch(e) { toast(e.message, true); }
+}
+
+// ── Modal ──────────────────────────────────────────────────────────────────
+function openModal(content) {
+  document.getElementById('modal-content').innerHTML = content;
+  document.getElementById('modal-backdrop').classList.add('open');
+}
+function closeModal() {
+  document.getElementById('modal-backdrop').classList.remove('open');
+}
+function closeModalBackdrop(e) {
+  if (e.target === document.getElementById('modal-backdrop')) closeModal();
+}
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') { closeModal(); closeDayDetail(); }
+});
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+function localTodayStr() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+function isTopicOverdue(t) {
+  return !t.completed && !t.archived && t.next_review_at.slice(0,10) < localTodayStr();
+}
+function esc(str) {
+  return String(str ?? '')
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+function formatDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { month:'short', day:'numeric', year:'numeric' });
+}
+
+// ── Init ───────────────────────────────────────────────────────────────────
+loadReview();
+loadProjectsData();
+</script>
+</body>
+</html>


### PR DESCRIPTION
- New `serve` command launches a local HTTP server with a vanillaJS SPA (web/server.go, web/handlers.go, web/static/index.html)
- Add `park` / `onboard` commands and database.ParkTopic / OnboardTopic; parked topics are excluded from review queues and stats.InProgress
- Add `review_logs` table; LogReview() called on every `done` to power per-day activity charts
- Extend fixed review schedule from 5 cycles (1→3→8→15→30) to 7 cycles (0→1→4→11→25→55→115 days); update all cycle bounds, tests, and docs
- Fix DueToday/Overdue split: DueToday covers end-of-day, Overdue is strict[118;1:3uly before start-of-day
- Add `--park` flag to `add`; return new topic ID from all insert helpers
- Add `ArchivedOnly` / `ParkedOnly` filter fields; switch list ordering to next_review_at DESC
- Add CLAUDE.md and task spec files (T-001 through T-007)